### PR TITLE
DPR2-281 sort column not required

### DIFF
--- a/src/dpr/components/report-list/utils.ts
+++ b/src/dpr/components/report-list/utils.ts
@@ -18,7 +18,7 @@ const filtersQueryParameterPrefix = 'filters.'
 
 function getDefaultSortColumn(fields: components['schemas']['FieldDefinition'][]) {
   const defaultSortColumn = fields.find((f) => f.defaultsort)
-  return defaultSortColumn ? defaultSortColumn.name : fields.find((f) => f.sortable).name
+  return defaultSortColumn ? defaultSortColumn.name : fields.find((f) => f.sortable)?.name
 }
 
 function isListWithWarnings(data: Dict<string>[] | ListWithWarnings): data is ListWithWarnings {


### PR DESCRIPTION
Changes in the frontend lib to support the sort column being optional. 