### PR TITLE
[DPR2-431] Keep column selection on sort/paging

### DIFF
--- a/cypress-tests/integration-tests/step-definitions/reports-list.ts
+++ b/cypress-tests/integration-tests/step-definitions/reports-list.ts
@@ -350,11 +350,11 @@ Then('the mandatory column value is shown in the URL', function (this: Mocha.Con
 
 Then('the selected columns values are shown in the URL', function (this: Mocha.Context) {
   cy.location().should((location) => {
-    expect(location.search).not.to.contain(`columns=field1`)
-    expect(location.search).to.contain(`columns=field2`)
-    expect(location.search).to.contain(`columns=field3`)
-    expect(location.search).to.contain(`columns=field4`)
-    expect(location.search).to.contain(`columns=field5`)
+    expect(location.search).to.not.match(/columns=[^&=]*field1/)
+    expect(location.search).to.match(/columns=[^&=]*field2/)
+    expect(location.search).to.match(/columns=[^&=]*field3/)
+    expect(location.search).to.match(/columns=[^&=]*field4/)
+    expect(location.search).to.match(/columns=[^&=]*field5/)
   })
 })
 

--- a/src/dpr/components/columns/utils.test.ts
+++ b/src/dpr/components/columns/utils.test.ts
@@ -72,12 +72,12 @@ describe('getColumns', () => {
 
 describe('getSelectedColumns', () => {
   it('mapped the selected columns correctly', () => {
-    const selectedColumns = Utils.getSelectedColumns(columns, queryColumns)
+    const selectedColumns = Utils.getSelectedColumns(fields, queryColumns)
     expect(selectedColumns).toEqual(queryColumns)
   })
 
   it('should always inlcude disabled columns', () => {
-    const selectedColumns = Utils.getSelectedColumns(columns, queryColumnNoDisabled)
+    const selectedColumns = Utils.getSelectedColumns(fields, queryColumnNoDisabled)
     expect(selectedColumns).toEqual(queryColumns)
   })
 })

--- a/src/dpr/components/columns/utils.ts
+++ b/src/dpr/components/columns/utils.ts
@@ -12,10 +12,6 @@ export default {
   },
 
   getSelectedColumns: (columns: Array<components['schemas']['FieldDefinition']>, queryCols: string[]) => {
-    console.log(columns)
-    console.log(queryCols)
-    return columns
-      .filter((column) => column.mandatory || queryCols.includes(column.name))
-      .map((field) => field.name)
+    return columns.filter((column) => column.mandatory || queryCols.includes(column.name)).map((field) => field.name)
   },
 }

--- a/src/dpr/components/columns/utils.ts
+++ b/src/dpr/components/columns/utils.ts
@@ -1,5 +1,4 @@
 import { components } from '../../types/api'
-import { Column } from './types'
 
 export default {
   getColumns: (fields: Array<components['schemas']['FieldDefinition']>) => {
@@ -12,7 +11,11 @@ export default {
     })
   },
 
-  getSelectedColumns: (columns: Column[], queryCols: string[]) => {
-    return columns.filter((column) => column.disabled || queryCols.includes(column.value)).map((field) => field.value)
+  getSelectedColumns: (columns: Array<components['schemas']['FieldDefinition']>, queryCols: string[]) => {
+    console.log(columns)
+    console.log(queryCols)
+    return columns
+      .filter((column) => column.mandatory || queryCols.includes(column.name))
+      .map((field) => field.name)
   },
 }

--- a/src/dpr/components/data-table/types.d.ts
+++ b/src/dpr/components/data-table/types.d.ts
@@ -16,7 +16,7 @@ export interface DataTableOptions {
   head: Array<Header>
   rows: Array<Array<Cell>>
   count: number
-  currentQueryParams: Dict<string>
+  currentQueryParams: Dict<string | Array<string>>
   classification: string
   printable?: boolean
   url: string

--- a/src/dpr/components/data-table/utils.test.ts
+++ b/src/dpr/components/data-table/utils.test.ts
@@ -165,15 +165,15 @@ describe('mapHeader', () => {
     type: 'date',
     mandatory: false,
   }
-  const defaultQueryParams = {}
+  const defaultQueryParams = {
+    columns: 'date'
+  }
   const filterPrefix = 'f.'
-  const columnsPrefix = 'c.'
   const defaultListRequest: ReportQuery = new ReportQuery(
     [defaultField],
     defaultQueryParams,
     null,
     filterPrefix,
-    columnsPrefix,
   )
   const createUrlForParameters: (currentQueryParams: Dict<string>, updateQueryParams: Dict<string>) => string = (
     currentQueryParams: Dict<string>,
@@ -185,7 +185,7 @@ describe('mapHeader', () => {
       ...defaultField,
       sortable: false,
     }
-    const mapped = Utils.mapHeader([field], defaultListRequest, createUrlForParameters, ['date'])
+    const mapped = Utils.mapHeader([field], defaultListRequest, createUrlForParameters)
 
     expect(mapped).toEqual([
       {
@@ -195,7 +195,7 @@ describe('mapHeader', () => {
   })
 
   it('Sortable unsorted field', () => {
-    const mapped = Utils.mapHeader([defaultField], defaultListRequest, createUrlForParameters, ['date'])
+    const mapped = Utils.mapHeader([defaultField], defaultListRequest, createUrlForParameters)
 
     expect(mapped).toEqual([
       {
@@ -220,9 +220,8 @@ describe('mapHeader', () => {
       },
       defaultField.name,
       filterPrefix,
-      columnsPrefix,
     )
-    const mapped = Utils.mapHeader([defaultField], reportQuery, createUrlForParameters, ['date'])
+    const mapped = Utils.mapHeader([defaultField], reportQuery, createUrlForParameters)
 
     expect(mapped).toEqual([
       {
@@ -248,9 +247,8 @@ describe('mapHeader', () => {
       },
       defaultField.name,
       filterPrefix,
-      columnsPrefix,
     )
-    const mapped = Utils.mapHeader([defaultField], reportQuery, createUrlForParameters, ['date'])
+    const mapped = Utils.mapHeader([defaultField], reportQuery, createUrlForParameters)
 
     expect(mapped).toEqual([
       {

--- a/src/dpr/components/data-table/utils.test.ts
+++ b/src/dpr/components/data-table/utils.test.ts
@@ -166,15 +166,10 @@ describe('mapHeader', () => {
     mandatory: false,
   }
   const defaultQueryParams = {
-    columns: 'date'
+    columns: 'date',
   }
   const filterPrefix = 'f.'
-  const defaultListRequest: ReportQuery = new ReportQuery(
-    [defaultField],
-    defaultQueryParams,
-    null,
-    filterPrefix,
-  )
+  const defaultListRequest: ReportQuery = new ReportQuery([defaultField], defaultQueryParams, null, filterPrefix)
   const createUrlForParameters: (currentQueryParams: Dict<string>, updateQueryParams: Dict<string>) => string = (
     currentQueryParams: Dict<string>,
     updateQueryParams: Dict<string>,

--- a/src/dpr/components/data-table/utils.ts
+++ b/src/dpr/components/data-table/utils.ts
@@ -22,14 +22,13 @@ export default {
   mapHeader: (
     format: Array<components['schemas']['FieldDefinition']>,
     reportQuery: ReportQuery,
-    createUrlForParameters: (currentQueryParams: Dict<string>, updateQueryParams: Dict<string>) => string,
-    selectedColumns: Array<string>,
+    createUrlForParameters: (currentQueryParams: Dict<string | Array<string>>, updateQueryParams: Dict<string>) => string,
   ) => {
     const currentQueryParams = reportQuery.toRecordWithFilterPrefix()
 
     return format
       .filter((f) => {
-        return selectedColumns.includes(f.name)
+        return reportQuery.columns.includes(f.name)
       })
       .map((f) => {
         let header: Header

--- a/src/dpr/components/data-table/utils.ts
+++ b/src/dpr/components/data-table/utils.ts
@@ -22,7 +22,10 @@ export default {
   mapHeader: (
     format: Array<components['schemas']['FieldDefinition']>,
     reportQuery: ReportQuery,
-    createUrlForParameters: (currentQueryParams: Dict<string | Array<string>>, updateQueryParams: Dict<string>) => string,
+    createUrlForParameters: (
+      currentQueryParams: Dict<string | Array<string>>,
+      updateQueryParams: Dict<string>,
+    ) => string,
   ) => {
     const currentQueryParams = reportQuery.toRecordWithFilterPrefix()
 

--- a/src/dpr/components/filters/types.d.ts
+++ b/src/dpr/components/filters/types.d.ts
@@ -1,11 +1,5 @@
 import { FilterType } from './enum'
 
-export interface FilterDefinition {
-  type: FilterType
-  options?: Array<FilterOption>
-  value?: string
-}
-
 export interface FilterOption {
   value: string
   text: string
@@ -23,7 +17,7 @@ export interface GenericFilterValue {
   dynamicResourceEndpoint?: string
 }
 
-export interface DateFilterValue extends FilterValue {
+export interface DateFilterValue extends GenericFilterValue {
   type: FilterType.dateRange
   value?: DateRange
   min?: string

--- a/src/dpr/components/filters/utils.test.ts
+++ b/src/dpr/components/filters/utils.test.ts
@@ -213,7 +213,9 @@ describe('getSelectedFilters', () => {
   })
 })
 
-const wrapInVariant = (fields: Array<components['schemas']['FieldDefinition']>): components['schemas']['VariantDefinition'] => {
+const wrapInVariant = (
+  fields: Array<components['schemas']['FieldDefinition']>,
+): components['schemas']['VariantDefinition'] => {
   return {
     id: 'test',
     name: 'Test',
@@ -222,7 +224,7 @@ const wrapInVariant = (fields: Array<components['schemas']['FieldDefinition']>):
       template: 'list',
       fields,
     },
-    classification: "",
+    classification: '',
     printable: false,
   }
 }

--- a/src/dpr/components/filters/utils.test.ts
+++ b/src/dpr/components/filters/utils.test.ts
@@ -27,6 +27,7 @@ const selectFieldFormat: Array<components['schemas']['FieldDefinition']> = [
     sortable: true,
     defaultsort: false,
     type: 'string',
+    mandatory: false,
   },
 ]
 
@@ -41,6 +42,7 @@ const radioFieldFormat: Array<components['schemas']['FieldDefinition']> = [
     sortable: true,
     defaultsort: false,
     type: 'string',
+    mandatory: false,
   },
 ]
 
@@ -54,6 +56,7 @@ const dateRangeFieldFormat: Array<components['schemas']['FieldDefinition']> = [
     sortable: true,
     defaultsort: false,
     type: 'string',
+    mandatory: false,
   },
 ]
 
@@ -116,6 +119,7 @@ describe('getFilters', () => {
         sortable: true,
         defaultsort: false,
         type: 'string',
+        mandatory: false,
       },
     ]
     const filterValues: Dict<string> = {
@@ -209,7 +213,7 @@ describe('getSelectedFilters', () => {
   })
 })
 
-const wrapInVariant = (fields: Array<components['schemas']['FieldDefinition']>) => {
+const wrapInVariant = (fields: Array<components['schemas']['FieldDefinition']>): components['schemas']['VariantDefinition'] => {
   return {
     id: 'test',
     name: 'Test',
@@ -218,5 +222,7 @@ const wrapInVariant = (fields: Array<components['schemas']['FieldDefinition']>) 
       template: 'list',
       fields,
     },
+    classification: "",
+    printable: false,
   }
 }

--- a/src/dpr/components/filters/utils.ts
+++ b/src/dpr/components/filters/utils.ts
@@ -60,7 +60,10 @@ export default {
   getSelectedFilters: (
     format: Array<components['schemas']['FieldDefinition']>,
     reportQuery: ReportQuery,
-    createUrlForParameters: (currentQueryParams: Dict<string | Array<string>>, updateQueryParams: Dict<string>) => string,
+    createUrlForParameters: (
+      currentQueryParams: Dict<string | Array<string>>,
+      updateQueryParams: Dict<string>,
+    ) => string,
   ) =>
     format
       .filter((f) => f.filter)

--- a/src/dpr/components/filters/utils.ts
+++ b/src/dpr/components/filters/utils.ts
@@ -60,7 +60,7 @@ export default {
   getSelectedFilters: (
     format: Array<components['schemas']['FieldDefinition']>,
     reportQuery: ReportQuery,
-    createUrlForParameters: (currentQueryParams: Dict<string>, updateQueryParams: Dict<string>) => string,
+    createUrlForParameters: (currentQueryParams: Dict<string | Array<string>>, updateQueryParams: Dict<string>) => string,
   ) =>
     format
       .filter((f) => f.filter)

--- a/src/dpr/components/report-list/utils.ts
+++ b/src/dpr/components/report-list/utils.ts
@@ -61,10 +61,7 @@ function redirectWithDefaultFilters(
   }
 
   if (Object.keys(defaultFilters).length > 0) {
-    const querystring = createUrlForParameters(
-      reportQuery.toRecordWithFilterPrefix(),
-      defaultFilters,
-    )
+    const querystring = createUrlForParameters(reportQuery.toRecordWithFilterPrefix(), defaultFilters)
     response.redirect(`${request.baseUrl}${request.path}${querystring}`)
     return true
   }

--- a/src/dpr/components/report-list/utils.ts
+++ b/src/dpr/components/report-list/utils.ts
@@ -14,7 +14,6 @@ import RenderListWithDefinitionInput from './RenderListWithDefinitionInput'
 import CreateRequestHandlerInput from './CreateRequestHandlerInput'
 
 const filtersQueryParameterPrefix = 'filters.'
-const columnsQueryParameterPrefix = 'columns'
 
 function getDefaultSortColumn(fields: components['schemas']['FieldDefinition'][]) {
   const defaultSortColumn = fields.find((f) => f.defaultsort)
@@ -65,7 +64,6 @@ function redirectWithDefaultFilters(
     const querystring = createUrlForParameters(
       reportQuery.toRecordWithFilterPrefix(),
       defaultFilters,
-      reportQuery.columns,
     )
     response.redirect(`${request.baseUrl}${request.path}${querystring}`)
     return true
@@ -103,16 +101,14 @@ function renderList(
           data = resolvedData[0]
         }
 
-        const columns = ColumnUtils.getColumns(fields)
-        const selectedColumns = ColumnUtils.getSelectedColumns(columns, reportQuery.columns)
         const columnOptions = {
-          columns,
-          selectedColumns,
+          columns: ColumnUtils.getColumns(fields),
+          selectedColumns: reportQuery.columns,
         }
 
         const dataTableOptions: DataTableOptions = {
-          head: DataTableUtils.mapHeader(fields, reportQuery, createUrlForParameters, selectedColumns),
-          rows: DataTableUtils.mapData(data, fields, selectedColumns),
+          head: DataTableUtils.mapHeader(fields, reportQuery, createUrlForParameters),
+          rows: DataTableUtils.mapData(data, fields, reportQuery.columns),
           count: resolvedData[1],
           currentQueryParams: reportQuery.toRecordWithFilterPrefix(),
           classification,
@@ -171,7 +167,6 @@ const renderListWithDefinition = ({
         request.query,
         getDefaultSortColumn(variantDefinition.specification.fields),
         filtersQueryParameterPrefix,
-        columnsQueryParameterPrefix,
       )
 
       const getListData: ListDataSources = {
@@ -216,7 +211,6 @@ export default {
       request.query,
       getDefaultSortColumn(fields),
       filtersQueryParameterPrefix,
-      columnsQueryParameterPrefix,
     )
     const listData = getListDataSources(reportQuery)
 

--- a/src/dpr/data/reportingClient.test.ts
+++ b/src/dpr/data/reportingClient.test.ts
@@ -20,6 +20,7 @@ describe('reportingClient', () => {
           type: 'Radio',
         },
         type: 'string',
+        mandatory: false,
       },
     ],
     {
@@ -69,6 +70,7 @@ describe('reportingClient', () => {
         sortedAsc: 'true',
         'f.original.filter': 'true',
         dataProductDefinitionsPath: 'test-definition-path',
+        columns: 'original.filter'
       }
       const resourceName = 'external-movements'
 

--- a/src/dpr/data/reportingClient.test.ts
+++ b/src/dpr/data/reportingClient.test.ts
@@ -70,7 +70,7 @@ describe('reportingClient', () => {
         sortedAsc: 'true',
         'f.original.filter': 'true',
         dataProductDefinitionsPath: 'test-definition-path',
-        columns: 'original.filter'
+        columns: 'original.filter',
       }
       const resourceName = 'external-movements'
 

--- a/src/dpr/types/ReportQuery.ts
+++ b/src/dpr/types/ReportQuery.ts
@@ -38,7 +38,8 @@ export default class ReportQuery implements FilteredListRequest {
     this.filtersPrefix = filtersPrefix
 
     if (queryParams.columns) {
-      const columns = typeof queryParams.columns === 'string' ? queryParams.columns.split(',') : (queryParams.columns as string[])
+      const columns =
+        typeof queryParams.columns === 'string' ? queryParams.columns.split(',') : (queryParams.columns as string[])
       this.columns = ColumnUtils.getSelectedColumns(fields, columns)
     } else {
       this.columns = fields.map((f) => f.name)

--- a/src/dpr/types/ReportQuery.ts
+++ b/src/dpr/types/ReportQuery.ts
@@ -3,6 +3,7 @@ import { FilteredListRequest } from './index'
 import Dict = NodeJS.Dict
 import { components } from './api'
 import { clearFilterValue } from '../utils/urlHelper'
+import ColumnUtils from '../components/columns/utils'
 
 export default class ReportQuery implements FilteredListRequest {
   selectedPage: number
@@ -19,8 +20,6 @@ export default class ReportQuery implements FilteredListRequest {
 
   filtersPrefix: string
 
-  columnsPrefix: string
-
   dataProductDefinitionsPath?: string
 
   constructor(
@@ -28,7 +27,6 @@ export default class ReportQuery implements FilteredListRequest {
     queryParams: ParsedQs,
     defaultSortColumn: string,
     filtersPrefix: string,
-    columnsPrefix: string,
   ) {
     this.selectedPage = queryParams.selectedPage ? Number(queryParams.selectedPage) : 1
     this.pageSize = queryParams.pageSize ? Number(queryParams.pageSize) : 20
@@ -38,10 +36,10 @@ export default class ReportQuery implements FilteredListRequest {
       ? queryParams.dataProductDefinitionsPath.toString()
       : null
     this.filtersPrefix = filtersPrefix
-    this.columnsPrefix = columnsPrefix
 
     if (queryParams.columns) {
-      this.columns = typeof queryParams.columns === 'string' ? [queryParams.columns] : (queryParams.columns as string[])
+      const columns = typeof queryParams.columns === 'string' ? queryParams.columns.split(',') : (queryParams.columns as string[])
+      this.columns = ColumnUtils.getSelectedColumns(fields, columns)
     } else {
       this.columns = fields.map((f) => f.name)
     }
@@ -56,12 +54,13 @@ export default class ReportQuery implements FilteredListRequest {
       })
   }
 
-  toRecordWithFilterPrefix(removeClearedFilters = false): Record<string, string> {
-    const record: Record<string, string> = {
+  toRecordWithFilterPrefix(removeClearedFilters = false): Record<string, string | Array<string>> {
+    const record: Record<string, string | Array<string>> = {
       selectedPage: this.selectedPage.toString(),
       pageSize: this.pageSize.toString(),
       sortColumn: this.sortColumn,
       sortedAsc: this.sortedAsc.toString(),
+      columns: this.columns,
     }
 
     if (this.dataProductDefinitionsPath) {

--- a/src/dpr/utils/urlHelper.test.ts
+++ b/src/dpr/utils/urlHelper.test.ts
@@ -13,6 +13,7 @@ const defaultFields: Array<components['schemas']['FieldDefinition']> = [
       type: 'Radio',
     },
     type: 'string',
+    mandatory: false
   },
 ]
 
@@ -51,7 +52,7 @@ describe('Create URL', () => {
 
     const url = createUrlForParameters(currentQueryParams.toRecordWithFilterPrefix(), updateQueryParams)
 
-    expect(url).toEqual('?selectedPage=10&pageSize=20&sortColumn=30&sortedAsc=false&f.direction=~clear~&f.type=jaunt')
+    expect(url).toEqual('?selectedPage=10&pageSize=20&sortColumn=30&sortedAsc=false&columns=direction&f.direction=~clear~&f.type=jaunt')
   })
 
   it('Change page with filters', () => {
@@ -61,6 +62,27 @@ describe('Create URL', () => {
 
     const url = createUrlForParameters(defaultReportQuery.toRecordWithFilterPrefix(), updateQueryParams)
 
-    expect(url).toEqual('?selectedPage=11&pageSize=20&sortColumn=30&sortedAsc=false&f.direction=out')
+    expect(url).toEqual('?selectedPage=11&pageSize=20&sortColumn=30&sortedAsc=false&columns=direction&f.direction=out')
+  })
+
+  it('Change page with column', () => {
+    const queryParams = {
+      selectedPage: '10',
+      pageSize: '20',
+      sortColumn: '30',
+      sortedAsc: 'false',
+      'f.direction': 'out',
+      columns: 'direction',
+    }
+
+    const reportQuery: ReportQuery = new ReportQuery(defaultFields, queryParams, 'one', 'f.')
+
+    const updateQueryParams: Dict<string> = {
+      selectedPage: '11',
+    }
+
+    const url = createUrlForParameters(reportQuery.toRecordWithFilterPrefix(), updateQueryParams)
+
+    expect(url).toEqual('?selectedPage=11&pageSize=20&sortColumn=30&sortedAsc=false&columns=direction&f.direction=out')
   })
 })

--- a/src/dpr/utils/urlHelper.test.ts
+++ b/src/dpr/utils/urlHelper.test.ts
@@ -13,7 +13,7 @@ const defaultFields: Array<components['schemas']['FieldDefinition']> = [
       type: 'Radio',
     },
     type: 'string',
-    mandatory: false
+    mandatory: false,
   },
 ]
 
@@ -52,7 +52,9 @@ describe('Create URL', () => {
 
     const url = createUrlForParameters(currentQueryParams.toRecordWithFilterPrefix(), updateQueryParams)
 
-    expect(url).toEqual('?selectedPage=10&pageSize=20&sortColumn=30&sortedAsc=false&columns=direction&f.direction=~clear~&f.type=jaunt')
+    expect(url).toEqual(
+      '?selectedPage=10&pageSize=20&sortColumn=30&sortedAsc=false&columns=direction&f.direction=~clear~&f.type=jaunt',
+    )
   })
 
   it('Change page with filters', () => {

--- a/src/dpr/utils/urlHelper.ts
+++ b/src/dpr/utils/urlHelper.ts
@@ -22,7 +22,6 @@ const createUrlForParameters = (
           })
       }
     })
-
   } else {
     queryParams = {
       selectedPage: '1',

--- a/src/dpr/utils/urlHelper.ts
+++ b/src/dpr/utils/urlHelper.ts
@@ -1,11 +1,10 @@
 export const clearFilterValue = '~clear~'
 
 const createUrlForParameters = (
-  currentQueryParams: NodeJS.Dict<string>,
+  currentQueryParams: NodeJS.Dict<string | Array<string>>,
   updateQueryParams: NodeJS.Dict<string>,
-  columns: Array<string> = [],
 ) => {
-  let queryParams: NodeJS.Dict<string>
+  let queryParams: NodeJS.Dict<string | Array<string>>
 
   if (updateQueryParams) {
     queryParams = {
@@ -24,11 +23,6 @@ const createUrlForParameters = (
       }
     })
 
-    if (columns.length) {
-      columns.forEach((col) => {
-        queryParams[`columns.${col}`] = col
-      })
-    }
   } else {
     queryParams = {
       selectedPage: '1',
@@ -39,7 +33,7 @@ const createUrlForParameters = (
     }
   }
 
-  const nonEmptyQueryParams: NodeJS.Dict<string> = {}
+  const nonEmptyQueryParams: NodeJS.Dict<string | Array<string>> = {}
 
   Object.keys(queryParams)
     .filter((key) => queryParams[key])
@@ -52,12 +46,7 @@ const createUrlForParameters = (
 
 export const createQuerystringFromObject = (source: object) => {
   const querystring = Object.keys(source)
-    .map((key) => {
-      let k = key
-      // eslint-disable-next-line prefer-destructuring
-      if (key.includes('columns.')) k = key.split('.')[0]
-      return `${encodeURI(k)}=${encodeURI(source[key as keyof typeof source])}`
-    })
+    .map((key) => `${encodeURI(key)}=${encodeURI(source[key])}`)
     .join('&')
 
   return `?${querystring}`


### PR DESCRIPTION
- Moved selected columns to ReportQuery so it's easy to pass with related information.
- Removed unused column prefix.
- Fixed some TypeScript complaints.