### PR TITLE
fix type issue seen in tools ui

### DIFF
--- a/src/dpr/utils/urlHelper.ts
+++ b/src/dpr/utils/urlHelper.ts
@@ -45,7 +45,7 @@ const createUrlForParameters = (
 
 export const createQuerystringFromObject = (source: object) => {
   const querystring = Object.keys(source)
-    .map((key) => `${encodeURI(key)}=${encodeURI(source[key])}`)
+    .map((key) => `${encodeURI(key)}=${encodeURI(source[key as keyof typeof source])}`)
     .join('&')
 
   return `?${querystring}`


### PR DESCRIPTION
Tools UI throws a typing error from the FE lib. 

```
error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'.
  No index signature with a parameter of type 'string' was found on type '{}'.

48     .map((key) => `${encodeURI(key)}=${encodeURI(source[key])}`)
```

The pr re-implements the fix for this.

