### PR TITLE
fix screen reader for data-table

### DIFF
--- a/src/dpr/components/data-table/clientClass.mjs
+++ b/src/dpr/components/data-table/clientClass.mjs
@@ -47,22 +47,22 @@ export default class DataTable extends DprLoadingClientClass {
       const header = table.createTHead()
       const footer = table.createTFoot()
 
-      const headerRow = header.insertRow(0)
+      const rowClassList = ['govuk-table__row', 'print-header-footer']
       const footerRow = footer.insertRow(0)
+      const headerRow = header.insertRow(0)
+      headerRow.classList.add(...rowClassList)
+      footerRow.classList.add(...rowClassList)
 
       const headerCell = headerRow.insertCell(0)
       const footerCell = footerRow.insertCell(0)
 
-      const classList = ['govuk-table__header', 'print-header-footer']
       const content = `<b>${classification}</b>`
 
       headerCell.colSpan = headLength
-      headerCell.classList.add(...classList)
-      headerCell.innerHTML = content
+      headerCell.outerHTML = `<th class="govuk-table__header govuk-table__cell--content" colspan=${headLength}>${content}</th>`
 
       footerCell.colSpan = headLength
-      footerCell.classList.add(...classList)
-      footerCell.innerHTML = content
+      footerCell.outerHTML = `<td class="govuk-table__cell govuk-table__cell--content" colspan=${headLength}>${content}</td>`
     }
   }
 }

--- a/src/dpr/components/data-table/style.scss
+++ b/src/dpr/components/data-table/style.scss
@@ -61,8 +61,8 @@
   min-width: 5em;
 }
 
-.print-header-footer {
-  display: none
+.govuk-table__cell--content {
+  text-align: center;
 }
 
 .data-table-empty-message {

--- a/src/dpr/components/data-table/view.njk
+++ b/src/dpr/components/data-table/view.njk
@@ -29,15 +29,15 @@
       <div>
         <div class="govuk-grid-column dpr-table-wrapper">
           {{ govukTable({
-        head: head,
-        rows: rows,
-        attributes: { 
-          'id': 'dpr-data-table',
-          'data-classification': classification,
-          'data-head-length': head.length,
-          'data-row-length': rows.length
-        }
-      }) }}
+            head: head,
+            rows: rows,
+            attributes: { 
+              'id': 'dpr-data-table',
+              'data-classification': classification,
+              'data-head-length': head.length,
+              'data-row-length': rows.length
+            }
+          }) }}
         </div>
       </div>
       <div class="pagination">

--- a/src/dpr/components/dropdown-button/style.scss
+++ b/src/dpr/components/dropdown-button/style.scss
@@ -92,11 +92,6 @@
     content: none;
   }
 
-  .print-header-footer {
-    display: table-cell;
-    text-align: center;
-  }
-
   .govuk-table__cell,
   .govuk-table__header {
     font-size: 14px;


### PR DESCRIPTION
Noticed that the screen reader was skipping over the table

This was due to the js for adding the classification thead + tfoot not being completely syntactically correct

This PR fixes this