### PR TITLE
datepicker min max fix

### DIFF
--- a/src/dpr/components/report-list/utils.ts
+++ b/src/dpr/components/report-list/utils.ts
@@ -168,8 +168,6 @@ const renderListWithDefinition = ({
         filtersQueryParameterPrefix,
       )
 
-      console.log({ reportQuery })
-
       const getListData: ListDataSources = {
         data: reportingClient.getListWithWarnings(variantDefinition.resourceName, token, reportQuery),
         count: reportingClient.getCount(variantDefinition.resourceName, token, reportQuery),

--- a/src/dpr/components/report-list/utils.ts
+++ b/src/dpr/components/report-list/utils.ts
@@ -168,6 +168,8 @@ const renderListWithDefinition = ({
         filtersQueryParameterPrefix,
       )
 
+      console.log({ reportQuery })
+
       const getListData: ListDataSources = {
         data: reportingClient.getListWithWarnings(variantDefinition.resourceName, token, reportQuery),
         count: reportingClient.getCount(variantDefinition.resourceName, token, reportQuery),

--- a/src/dpr/types/ReportQuery.ts
+++ b/src/dpr/types/ReportQuery.ts
@@ -45,13 +45,31 @@ export default class ReportQuery implements FilteredListRequest {
       this.columns = fields.filter((f) => f.visible).map((f) => f.name)
     }
 
+    let min: string
+    let max: string
+    const dateField = fields.find((f) => f.type === 'date')
+    if (dateField && dateField.filter) {
+      ;({ min, max } = dateField.filter)
+    }
+
     this.filters = {}
 
     Object.keys(queryParams)
       .filter((key) => key.startsWith(filtersPrefix))
       .filter((key) => queryParams[key])
       .forEach((key) => {
-        this.filters[key.replace(filtersPrefix, '')] = queryParams[key].toString()
+        const filter = key.replace(filtersPrefix, '')
+        let value = queryParams[key].toString()
+
+        if (filter.includes('.start') && min) {
+          if (new Date(value) < new Date(min)) value = min
+        }
+
+        if (filter.includes('.end') && max) {
+          if (new Date(value) > new Date(max)) value = max
+        }
+
+        this.filters[filter] = value
       })
   }
 

--- a/src/dpr/types/ReportQuery.ts
+++ b/src/dpr/types/ReportQuery.ts
@@ -47,10 +47,10 @@ export default class ReportQuery implements FilteredListRequest {
 
     let min: string
     let max: string
-    const dateField = fields.find((f) => f.type === 'date')
-    if (dateField && dateField.filter) {
-      ;({ min, max } = dateField.filter)
-    }
+    const dateField: components['schemas']['FieldDefinition'] = fields.find(
+      (f) => f.type === 'date' && dateField.filter,
+    )
+    if (dateField) ({ min, max } = dateField.filter)
 
     this.filters = {}
 

--- a/src/dpr/types/ReportQuery.ts
+++ b/src/dpr/types/ReportQuery.ts
@@ -48,7 +48,7 @@ export default class ReportQuery implements FilteredListRequest {
     let min: string
     let max: string
     const dateField: components['schemas']['FieldDefinition'] = fields.find(
-      (f) => f.type === 'date' && dateField.filter,
+      (f) => f.type === 'date' && f.filter && f.filter.type === 'daterange',
     )
     if (dateField) ({ min, max } = dateField.filter)
 
@@ -60,15 +60,12 @@ export default class ReportQuery implements FilteredListRequest {
       .forEach((key) => {
         const filter = key.replace(filtersPrefix, '')
         let value = queryParams[key].toString()
-
         if (filter.includes('.start') && min) {
           if (new Date(value) < new Date(min)) value = min
         }
-
         if (filter.includes('.end') && max) {
           if (new Date(value) > new Date(max)) value = max
         }
-
         this.filters[filter] = value
       })
   }


### PR DESCRIPTION
Fix to datepicker min and max values:

- Updating the URL outside the min and max date filter constraints was not updating the API request correctly, therefore returning all results and ignoring the constraints. 

This PR fixes the issue by intercepting the filter params and modifying the start and end date values in api request if they le outside the constraints.

 
