### PR TITLE
[DPR2-525] Update publish action to avoid writing to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,19 +6,16 @@ on:
       versionType:
         description: 'The semantic version segment to increment'
         required: true
-        default: minor
+        default: feature
         type: choice
         options:
           - major
-          - minor
-          - patch
+          - feature
+          - bug
 
 jobs:
   publish-package:
     runs-on: ubuntu-latest
-
-    permissions:
-      contents: write
 
     steps:
     - uses: actions/checkout@v3
@@ -27,16 +24,24 @@ jobs:
         node-version: 'lts/*'
     - run: npm ci
     - run: npm run package
-    - name: 'Automated Version Bump'
-      uses: 'phips28/gh-action-bump-version@master'
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        PACKAGEJSON_DIR: package
+
+    - name: Get version
+      id: get-version
+      run: |
+        CURRENT_VERSION=$(npm view @ministryofjustice/hmpps-digital-prison-reporting-frontend version)
+        echo "Current version: $CURRENT_VERSION"
+        echo "current_version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+
+    - name: Bump version
+      id: bump-version
+      uses: christian-draeger/increment-semantic-version@1.1.0
       with:
-        version-type: ${{ inputs.versionType }}
-        tag-prefix:  'v'
-        target-branch: 'main'
-        commit-message: 'Publish version {{version}}'
+        current-version: ${{ steps.get-version.outputs.current_version }}
+        version-fragment: ${{ inputs.versionType }}
+
+    - name: Set version
+      run: sed -i -e 's/Version set by script/${{ steps.bump-version.outputs.next-version }}/' package/package.json
+
     - uses: JS-DevTools/npm-publish@v1
       with:
         token: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,12 @@
 Below you can find the changes included in each release.
 
-## v3.5.3
+## v3.7.1
 
-Added changelog.
+Updated publish action to avoid writing to main. 
 
-## v3.5.4
+## v3.7.0
 
-Report List improvements
-
-## v3.5.6
-
-Add accessibility testing to CICD and fix highlighted issues.
-
-## v3.5.7
-
-Avoid reformatting dates that are the product of a formula.
+Support more word wrapping options, and more field types.
 
 ## v3.6.0
 
@@ -22,6 +14,18 @@ Avoid reformatting dates that are the product of a formula.
 - Menu card loading state
 - Total Results count displayed on report list
 
-## v3.7.0
+## v3.5.7
 
-Support more word wrapping options, and more field types.
+Avoid reformatting dates that are the product of a formula.
+
+## v3.5.6
+
+Add accessibility testing to CICD and fix highlighted issues.
+
+## v3.5.4
+
+Report List improvements
+
+## v3.5.3
+
+Added changelog.

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ministryofjustice/hmpps-digital-prison-reporting-frontend",
   "description": "The Digital Prison Reporting Frontend contains templates and code to help display data effectively in UI applications.",
-  "version": "3.7.0",
+  "version": "Version set by script",
   "main": "dpr/assets/js/all.mjs",
   "sass": "dpr/all.scss",
   "engines": {


### PR DESCRIPTION
Old process:
- Increment the version in the local workspace.
- Commit the new version to main.
- Publish from the workspace.

New process:
- Retrieves the latest version of the library using npm.
- Increments the version according to the selected type.
- Pushes the version to the local workspace (replacing a placeholder token).
- Publishes the locally-saved version.

By avoiding this commit to main, we can restrict access to the main branch (since there isn't a specific GitHub Action user to grant access to).