### PR TITLE
[DPR2-170] Fix documentation examples

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -74,7 +74,7 @@ module.exports = function (eleventyConfig) {
         .trim();
     } catch (e) {}
 
-    return nunjucksEnv.render("example.njk", {
+    const renderedExample = nunjucksEnv.render("example.njk", {
       href: "/examples/" + exampleName,
       id: exampleName,
       arguments: data.arguments,
@@ -85,6 +85,10 @@ module.exports = function (eleventyConfig) {
       htmlCode,
       jsCode,
     });
+
+    // GovUK tabs now add a bunch of whitespace in front of their content.
+    // This means Eleventy doesn't spot the markdown tokens unless we remove the whitespace.
+    return renderedExample.replace(/ +(```|#|\|)/g, '$1')
   });
 
   eleventyConfig.addShortcode("version", function () {

--- a/docs/_includes/example.njk
+++ b/docs/_includes/example.njk
@@ -23,9 +23,7 @@
       </span>
       </summary>
       <div class="govuk-details__text">
-
         {% include "./arguments/" + arguments + ".md" %}
-
       </div>
     </details>
   {% endif %}

--- a/docs/get-started/integrating-the-library.md
+++ b/docs/get-started/integrating-the-library.md
@@ -15,13 +15,13 @@ These steps assume your project is already using the Gov.uk and MoJ libraries, a
 
 Add the library to your **package.json** within the **dependencies** section and run **npm install**:
 
-```
+```javascript
 "@ministryofjustice/hmpps-digital-prison-reporting-frontend": "^3",
 ```
 
 Ensure that you have the following dependency in the expected range, to ensure compatibility between the libraries:
 
-```
+```javascript
 "govuk-frontend": "^5.3.0",
 ```
 
@@ -64,9 +64,9 @@ Add the client-side JavaScript to the nunjucks layout:
 
 Alternatively, to avoid Chrome objecting to running scripts in line, you can add the initialisation to a separate JS file (in this example named "dprInit.mjs"):
 ```javascript
-  import initAll from "/assets/dpr/js/all.mjs";
+import initAll from "/assets/dpr/js/all.mjs";
 
-  initAll();
+initAll();
 ```
 
 And then include it to initialise the JavaScript:

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "jest-junit": "^16.0.0",
         "js-beautify": "^1.14.9",
         "lint-staged": "^13.2.3",
-        "markdown-it": "^13.0.2",
+        "markdown-it": "^14.1.0",
         "markdown-it-anchor": "^8.6.7",
         "mocha-junit-reporter": "^2.2.1",
         "nock": "^13.3.8",
@@ -195,6 +195,43 @@
         "type": "opencollective",
         "url": "https://opencollective.com/11ty"
       }
+    },
+    "node_modules/@11ty/eleventy/node_modules/linkify-it": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
+      "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
+      "dev": true,
+      "dependencies": {
+        "uc.micro": "^1.0.1"
+      }
+    },
+    "node_modules/@11ty/eleventy/node_modules/markdown-it": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.2.tgz",
+      "integrity": "sha512-FtwnEuuK+2yVU7goGn/MJ0WBZMM9ZPgU9spqlFs7/A/pDIUNSOQZhUgOqYCficIuR2QaFnrt8LHqBWsbTAoI5w==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "~3.0.1",
+        "linkify-it": "^4.0.1",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.js"
+      }
+    },
+    "node_modules/@11ty/eleventy/node_modules/mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
+      "dev": true
+    },
+    "node_modules/@11ty/eleventy/node_modules/uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "dev": true
     },
     "node_modules/@11ty/lodash-custom": {
       "version": "4.17.21",
@@ -12620,12 +12657,12 @@
       "dev": true
     },
     "node_modules/linkify-it": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
-      "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
       "dev": true,
       "dependencies": {
-        "uc.micro": "^1.0.1"
+        "uc.micro": "^2.0.0"
       }
     },
     "node_modules/lint-staged": {
@@ -13470,19 +13507,20 @@
       "dev": true
     },
     "node_modules/markdown-it": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.2.tgz",
-      "integrity": "sha512-FtwnEuuK+2yVU7goGn/MJ0WBZMM9ZPgU9spqlFs7/A/pDIUNSOQZhUgOqYCficIuR2QaFnrt8LHqBWsbTAoI5w==",
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
       "dev": true,
       "dependencies": {
         "argparse": "^2.0.1",
-        "entities": "~3.0.1",
-        "linkify-it": "^4.0.1",
-        "mdurl": "^1.0.1",
-        "uc.micro": "^1.0.5"
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
       },
       "bin": {
-        "markdown-it": "bin/markdown-it.js"
+        "markdown-it": "bin/markdown-it.mjs"
       }
     },
     "node_modules/markdown-it-anchor": {
@@ -13493,6 +13531,18 @@
       "peerDependencies": {
         "@types/markdown-it": "*",
         "markdown-it": "*"
+      }
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/marked": {
@@ -13614,9 +13664,9 @@
       "dev": true
     },
     "node_modules/mdurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "dev": true
     },
     "node_modules/media-typer": {
@@ -19179,6 +19229,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pure-rand": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
@@ -22044,9 +22103,9 @@
       }
     },
     "node_modules/uc.micro": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "dev": true
     },
     "node_modules/uglify-js": {

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "jest-junit": "^16.0.0",
     "js-beautify": "^1.14.9",
     "lint-staged": "^13.2.3",
-    "markdown-it": "^13.0.2",
+    "markdown-it": "^14.1.0",
     "markdown-it-anchor": "^8.6.7",
     "mocha-junit-reporter": "^2.2.1",
     "nock": "^13.3.8",


### PR DESCRIPTION
This fixes an issue with GovUK v5 tabs, where whitespace is being added before the tab content.

The extra whitespace meant the markdown processor was missing the example code blocks.