### PR TITLE
fix sort direction summary bug

### DIFF
--- a/src/dpr/components/async-filters/utils.ts
+++ b/src/dpr/components/async-filters/utils.ts
@@ -165,7 +165,7 @@ const setQuerySummary = (req: Request, fields: components['schemas']['FieldDefin
         const fieldDef = DefinitionUtils.getField(fields, value)
 
         let displayName = 'Sort Direction'
-        let displayValue = value ? 'Ascending' : 'Descending'
+        let displayValue = value === 'true' ? 'Ascending' : 'Descending'
         if (fieldDef) {
           displayName = 'Sort Column'
           displayValue = fieldDef.display


### PR DESCRIPTION
Filter summary bug not showing correct direction - always shows 'Ascending' because bool value is actually a string. So updated the condition to fix