### PR TITLE
Not Found bug when DPD is bookmarked then deleted

### DIFF
--- a/src/dpr/utils/bookmarkListUtils.ts
+++ b/src/dpr/utils/bookmarkListUtils.ts
@@ -81,18 +81,19 @@ const mapBookmarkIdsToDefinition = async (
           bookmark.variantId,
           <string>definitionPath,
         )
+        if (definition) {
+          bookmarkData.push({
+            reportId: bookmark.reportId,
+            variantId: bookmark.variantId,
+            reportName: definition.name,
+            name: definition.variant.name,
+            description: definition.variant.description,
+            href: `/async-reports/${bookmark.reportId}/${bookmark.variantId}/request`,
+          })
+        }
       } catch (error) {
-        // Do nothing. DPD has been deleted
-      }
-      if (definition) {
-        bookmarkData.push({
-          reportId: bookmark.reportId,
-          variantId: bookmark.variantId,
-          reportName: definition.name,
-          name: definition.variant.name,
-          description: definition.variant.description,
-          href: `/async-reports/${bookmark.reportId}/${bookmark.variantId}/request`,
-        })
+        // DPD has been deleted so API throws error
+        await services.bookmarkService.removeBookmark(bookmark.variantId)
       }
     }),
   )

--- a/src/dpr/utils/bookmarkListUtils.ts
+++ b/src/dpr/utils/bookmarkListUtils.ts
@@ -73,12 +73,17 @@ const mapBookmarkIdsToDefinition = async (
 
   await Promise.all(
     bookmarks.map(async (bookmark) => {
-      const definition = await services.reportingService.getDefinition(
-        token,
-        bookmark.reportId,
-        bookmark.variantId,
-        <string>definitionPath,
-      )
+      let definition
+      try {
+        definition = await services.reportingService.getDefinition(
+          token,
+          bookmark.reportId,
+          bookmark.variantId,
+          <string>definitionPath,
+        )
+      } catch (error) {
+        // Do nothing. DPD has been deleted
+      }
       if (definition) {
         bookmarkData.push({
           reportId: bookmark.reportId,


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/DPR2-982

The bookmarks use the definitions api to populate the items. If a DPD is deleted an API error is thrown by the definition API but not caught and dealt with. In this case it should be a none blocking error and not add the bookmark to the list. 