### PR TITLE
Expired + Failed Report managment

### DIFF
--- a/src/dpr/DprQueryParamClass.mjs
+++ b/src/dpr/DprQueryParamClass.mjs
@@ -117,7 +117,7 @@ export default class DprQueryParamClass extends DprClientClass {
    * @memberof DprQueryParamClass
    */
   clearQueryParams () {
-    const sacredParams = ['dataProductDefinitionsPath', 'retryId']
+    const sacredParams = ['dataProductDefinitionsPath']
     this.queryParams = new URLSearchParams(window.location.search)
     const params = Array.from(this.queryParams)
     params.forEach((p) => {

--- a/src/dpr/components/async-filters/clientClass.mjs
+++ b/src/dpr/components/async-filters/clientClass.mjs
@@ -16,7 +16,6 @@ export default class AsyncFilters extends DprQueryParamClass {
 
     this.initResetButton()
     this.initSubmitButton()
-    this.initRetryInputFromQueryParams()
     this.initFormData()
   }
 
@@ -27,8 +26,6 @@ export default class AsyncFilters extends DprQueryParamClass {
     document.getElementById('async-filters-form-search').value = search
 
     const params = new URLSearchParams(search)
-    params.delete('retryId')
-    params.delete('refreshId')
     const href = `${origin}${pathname}?${params.toString()}`
 
     document.getElementById('async-filters-form-href').value = href
@@ -48,17 +45,5 @@ export default class AsyncFilters extends DprQueryParamClass {
       this.clearQueryParams()
       window.location.reload()
     })
-  }
-
-  initRetryInputFromQueryParams () {
-    this.queryParams = new URLSearchParams(window.location.search)
-    const retryId = this.queryParams.get('retryId')
-    const refreshId = this.queryParams.get('refreshId')
-    if (retryId) {
-      document.getElementById('async-filters-retry-id').value = retryId
-    }
-    if (refreshId) {
-      document.getElementById('async-filters-refresh-id').value = refreshId
-    }
   }
 }

--- a/src/dpr/components/async-filters/utils.test.ts
+++ b/src/dpr/components/async-filters/utils.test.ts
@@ -41,6 +41,7 @@ describe('AsyncFiltersUtils', () => {
         setReportTimestamp: jest.fn(),
       },
       recentlyViewedStoreService: {
+        getAllReportsByVariantId: jest.fn().mockResolvedValue([]),
         setReportTimestamp: jest.fn(),
       },
     } as unknown as Services
@@ -67,8 +68,6 @@ describe('AsyncFiltersUtils', () => {
         'filters.field4': 'Fezzick',
         sortBy: 'field5',
         sortDirection: 'true',
-        retryId: 'retryId',
-        refreshId: 'refreshId',
         search: 'search',
         variantId: 'variantId',
       },

--- a/src/dpr/components/async-filters/view.njk
+++ b/src/dpr/components/async-filters/view.njk
@@ -37,13 +37,13 @@
       <input type="hidden" name="origin" id="async-filters-form-origin" value="">
       <input type="hidden" name="href" id="async-filters-form-href" value="">
       <input type="hidden" name="search" id="async-filters-form-search" value="">
-      <input type="hidden" name="retryId" id="async-filters-retry-id" value="">
-      <input type="hidden" name="refreshId" id="async-filters-refresh-id" value="">
 
-      <div class="dpr-async-controls__section govuk-!-margin-top-4">
-        <h3 class="govuk-heading-s">Filters</h3>
-        {{ dprAsyncFilterInputs(filters, 'filters.') }}
-      </div>
+      {% if filters.length %}
+        <div class="dpr-async-controls__section govuk-!-margin-top-4">
+          <h3 class="govuk-heading-s">Filters</h3>
+          {{ dprAsyncFilterInputs(filters, 'filters.') }}
+        </div>
+      {% endif %}
 
       <div class="dpr-async-controls__section">
         <h3 class="govuk-heading-s">Sort By</h3>

--- a/src/dpr/components/async-polling/view.njk
+++ b/src/dpr/components/async-polling/view.njk
@@ -89,7 +89,7 @@
         id: "retry-async-request",
         text: "Retry",  
         classes: "govuk-button govuk-!-margin-top-5",
-        href: requestUrl + '&retryId=' + executionId
+        href: requestUrl
       }) }}
 
     {% endif %}

--- a/src/dpr/components/async-request-list/utils.test.ts
+++ b/src/dpr/components/async-request-list/utils.test.ts
@@ -46,7 +46,7 @@ describe('AsyncRequestListUtils', () => {
     it('should set the correct href and timestamp for ABORTED status', async () => {
       const result = setDataFromStatus(RequestStatus.ABORTED, reportData)
       const expectedResult = {
-        href: 'requestUrl&retryId=executionId',
+        href: 'requestUrl',
         timestamp: 'Aborted at: Invalid Date',
       }
       expect(result).toEqual(expectedResult)
@@ -64,7 +64,7 @@ describe('AsyncRequestListUtils', () => {
     it('should set the correct href and timestamp for EXPIRED status', async () => {
       const result = setDataFromStatus(RequestStatus.EXPIRED, reportData)
       const expectedResult = {
-        href: 'requestUrl&retryId=executionId',
+        href: 'requestUrl',
         timestamp: 'Expired at: Invalid Date',
       }
       expect(result).toEqual(expectedResult)

--- a/src/dpr/components/async-request-list/utils.ts
+++ b/src/dpr/components/async-request-list/utils.ts
@@ -42,7 +42,6 @@ export const setDataFromStatus = (status: RequestStatus, requestedReportsData: A
   let timestamp
   let href
   const { url, timestamp: time } = requestedReportsData
-  const retryParam = `&retryId=${requestedReportsData.executionId}`
   switch (status) {
     case RequestStatus.FAILED: {
       const failedTime = time.failed ? new Date(time.failed).toLocaleString() : new Date().toLocaleString()
@@ -51,7 +50,7 @@ export const setDataFromStatus = (status: RequestStatus, requestedReportsData: A
       break
     }
     case RequestStatus.ABORTED: {
-      href = `${url.request.fullUrl}${retryParam}`
+      href = `${url.request.fullUrl}`
       timestamp = `Aborted at: ${new Date(time.aborted).toLocaleString()}`
       break
     }
@@ -60,7 +59,7 @@ export const setDataFromStatus = (status: RequestStatus, requestedReportsData: A
       timestamp = `Ready at: ${new Date(time.completed).toLocaleString()}`
       break
     case RequestStatus.EXPIRED: {
-      href = `${url.request.fullUrl}${retryParam}`
+      href = `${url.request.fullUrl}`
       timestamp = `Expired at: ${new Date(time.expired).toLocaleString()}`
       break
     }
@@ -82,7 +81,7 @@ export const setDataFromStatus = (status: RequestStatus, requestedReportsData: A
 }
 
 export const filterReports = (report: AsyncReportData) => {
-  return !report.timestamp.lastViewed && !report.timestamp.retried
+  return !report.timestamp.lastViewed
 }
 
 export default {

--- a/src/dpr/components/icon-button-list/utils.ts
+++ b/src/dpr/components/icon-button-list/utils.ts
@@ -52,7 +52,7 @@ const initReportActions = (
   if (executionId) {
     actions.push({
       ...BUTTON_TEMPLATES.refresh,
-      href: `${url}&refreshId=${executionId}`,
+      href: url,
     })
   }
 

--- a/src/dpr/components/recently-viewed-list/clientClass.mjs
+++ b/src/dpr/components/recently-viewed-list/clientClass.mjs
@@ -8,7 +8,7 @@ export default class DprRecentlyViewedList extends DprPollingStatusClass {
 
   initialise () {
     this.POLLING_STATUSES = []
-    this.POLLING_FREQUENCY = '300000' // 5 mins
+    this.POLLING_FREQUENCY = '60000' // 1 min
 
     this.viewedList = document.getElementById('dpr-recently-viewed-component')
     this.viewedReportData = this.viewedList.getAttribute('data-request-data')

--- a/src/dpr/components/recently-viewed-list/utils.ts
+++ b/src/dpr/components/recently-viewed-list/utils.ts
@@ -22,7 +22,7 @@ export const formatCardData = (reportData: RecentlyViewedReportData): CardData =
 
   let href
   if (status === RequestStatus.EXPIRED) {
-    href = `${url.request.fullUrl}&retryId=${executionId}`
+    href = `${url.request.fullUrl}`
   } else {
     status = RequestStatus.READY
     href = url.report.fullUrl
@@ -48,7 +48,7 @@ export const formatCardData = (reportData: RecentlyViewedReportData): CardData =
 }
 
 export const filterReports = (report: RecentlyViewedReportData) => {
-  return !report.timestamp.retried && !report.timestamp.refresh
+  return report.executionId.length !== 0
 }
 
 export default {

--- a/src/dpr/services/recentlyViewedService.ts
+++ b/src/dpr/services/recentlyViewedService.ts
@@ -36,6 +36,12 @@ export default class RecentlyViewedStoreService extends UserStoreService {
     return this.recentlyViewedReports
   }
 
+  async getAllReportsByVariantId(variantId: string) {
+    return this.recentlyViewedReports.filter((report) => {
+      return report.variantId === variantId
+    })
+  }
+
   reportExists(id: string) {
     return this.recentlyViewedReports.filter((rec) => rec.executionId === id).length > 0
   }
@@ -75,6 +81,7 @@ export default class RecentlyViewedStoreService extends UserStoreService {
         origin: url.origin,
         request: {
           fullUrl: url.request.fullUrl,
+          search: url.request.search,
         },
         report: {
           fullUrl: url.report.fullUrl,

--- a/src/dpr/utils/reportStatusHelper.test.ts
+++ b/src/dpr/utils/reportStatusHelper.test.ts
@@ -4,7 +4,7 @@ import { RequestStatus } from '../types/AsyncReport'
 import { Services } from '../types/Services'
 import * as ReportStatusHelper from './reportStatusHelper'
 
-describe('ReportStatusUtils', () => {
+describe('ReportStatusHelper', () => {
   const services: Services = {
     asyncReportsStore: {},
     recentlyViewedStoreService: {},
@@ -102,7 +102,7 @@ describe('ReportStatusUtils', () => {
       const req = {
         body: {
           executionId: 'executionId',
-          status: RequestStatus.FINISHED,
+          status: RequestStatus.READY,
           requestedAt: new Date(),
         },
       } as unknown as Request

--- a/src/dpr/utils/reportStatusHelper.ts
+++ b/src/dpr/utils/reportStatusHelper.ts
@@ -76,7 +76,7 @@ export const getExpiredStatus = async ({ req, res, services }: AsyncReportUtilsP
   } catch (error) {
     const { data } = error
     errorMessage = (data ?? {}).userMessage
-    status = currentStatus === RequestStatus.FINISHED ? RequestStatus.EXPIRED : RequestStatus.FAILED
+    status = currentStatus === RequestStatus.READY ? RequestStatus.EXPIRED : RequestStatus.FAILED
   }
 
   const result: GetStatusUtilsResponse = {

--- a/src/dpr/utils/reportSummaryHelper.ts
+++ b/src/dpr/utils/reportSummaryHelper.ts
@@ -1,5 +1,6 @@
 import { CardData } from '../components/table-card-group/types'
 import { AsyncReportData } from '../types/AsyncReport'
+import { RecentlyViewedReportData } from '../types/RecentlyViewed'
 
 export const createDetailsHtml = (title: string, content: string) => {
   return `<details class="govuk-details">
@@ -19,11 +20,22 @@ export const createSummaryHtml = (card: CardData) => {
   return `<ul class="dpr-card-group__item__filters-list">${summaryHtml}</ul>`
 }
 
-export const getDuplicateRequestIds = (newReportSearchParams: string, existingReports: AsyncReportData[]) => {
+/**
+ * Gets the execution IDs of duplicate requests
+ * - Checks whether the request query are the same
+ *
+ * @param {string} newReportSearchParams
+ * @param {AsyncReportData[]} existingReports
+ * @return {string[]}  ids of the duplicate requests
+ */
+export const getDuplicateRequestIds = (
+  newReportSearchParams: string,
+  existingReports: AsyncReportData[] | RecentlyViewedReportData[],
+) => {
   const duplicates: string[] = []
   const newQueryParams = new URLSearchParams(newReportSearchParams)
 
-  existingReports.forEach((existingReportData: AsyncReportData) => {
+  existingReports.forEach((existingReportData: AsyncReportData | RecentlyViewedReportData) => {
     const matches: boolean[] = []
     const existingQueryParams = new URLSearchParams(existingReportData.url.request.search)
 

--- a/src/dpr/utils/reportsListHelper.test.ts
+++ b/src/dpr/utils/reportsListHelper.test.ts
@@ -1,9 +1,7 @@
 import * as ReportsListHelper from './reportsListHelper'
 import { filterReports, formatCardData } from '../components/async-request-list/utils'
-import * as recentlyViewedUtils from '../components/recently-viewed-list/utils'
 import mockRedisData from '../../../test-app/mockAsyncData/mockRedisReportData'
 import { AsyncReportData } from '../types/AsyncReport'
-import { RecentlyViewedReportData } from '../types/RecentlyViewed'
 
 describe('ReportsListHelper', () => {
   describe('formatCards', () => {
@@ -12,24 +10,14 @@ describe('ReportsListHelper', () => {
       jest.clearAllMocks()
     })
 
-    it('should filter out retried and last viewed items for requested reports', async () => {
+    it('should filter out last viewed items for requested reports', async () => {
       const result = await ReportsListHelper.formatCards(
         mockRedisData.mockRequestedReports as AsyncReportData[],
         filterReports,
         formatCardData,
       )
 
-      expect(result.length).toEqual(1)
-    })
-
-    it('should filter out retried and last viewed items for requested reports', async () => {
-      const result = await ReportsListHelper.formatCards(
-        mockRedisData.mockViewedReports as RecentlyViewedReportData[],
-        recentlyViewedUtils.filterReports,
-        recentlyViewedUtils.formatCardData,
-      )
-
-      expect(result.length).toEqual(1)
+      expect(result.length).toEqual(2)
     })
   })
 })

--- a/test-app/mockAsyncData/mockAsyncApis.js
+++ b/test-app/mockAsyncData/mockAsyncApis.js
@@ -9,7 +9,7 @@ const mockAPIStatus = []
 const happyStatuses = ['SUBMITTED', 'PICKED', 'STARTED', 'FINISHED']
 const sadStatuses = ['SUBMITTED', 'PICKED', 'STARTED', 'FAILED']
 const sadServerStatuses = ['SUBMITTED', 'PICKED', 500]
-const expiredStatuses = ['SUBMITTED', 'PICKED', 'STARTED', 'FINISHED', 'READY', 'EXPIRED']
+const expiredStatuses = ['SUBMITTED', 'PICKED', 'STARTED', 'FINISHED', 'READY', 500]
 const RESULT_COUNT = 100
 
 const getAsyncReportStatus = (token, reportId, variantId, executionId) => {
@@ -101,9 +101,9 @@ const getAsyncSummaryReport = (token, reportId, variantId, tableId, summaryId) =
     case 'summary3':
       return Promise.resolve([{ percentGood: 45, percentBad: 10, percentUgly: 98 }])
     case 'summary4':
-      return Promise.resolve([{ field1: 57, field2: 1, field3: 12219380923, field4: '3 Freds'  }])
+      return Promise.resolve([{ field1: 57, field2: 1, field3: 12219380923, field4: '3 Freds' }])
     case 'summary5':
-      return Promise.resolve([{ field1: 'Percentageness', field2: '10%', field3: '20%', field4: '90%'  }])
+      return Promise.resolve([{ field1: 'Percentageness', field2: '10%', field3: '20%', field4: '90%' }])
     default:
       return Promise.resolve([{ total: 52 }])
   }

--- a/test-app/mockAsyncData/mockReportDefinition.js
+++ b/test-app/mockAsyncData/mockReportDefinition.js
@@ -1458,6 +1458,75 @@ const variant12 = {
   },
 }
 
+const variant13 = {
+  id: 'variantId-13',
+  name: 'Test Variant 13',
+  description: 'No filters or Sort columns',
+  resourceName: 'reports/list',
+  classification: 'OFFICIAL',
+  printable: false,
+  specification: {
+    template: 'list',
+    fields: [
+      {
+        name: 'field1',
+        display: 'Field 1',
+        sortable: false,
+        type: 'string',
+        mandatory: false,
+        visible: true,
+      },
+      {
+        name: 'field2',
+        display: 'Field 2',
+        sortable: false,
+        type: 'string',
+        mandatory: true,
+        visible: true,
+      },
+      {
+        name: 'field3',
+        display: 'Field 3',
+        sortable: false,
+        visible: true,
+        type: 'date',
+        mandatory: false,
+      },
+      {
+        name: 'field4',
+        display: 'Field 4',
+        visible: false,
+        sortable: false,
+        type: 'string',
+      },
+      {
+        name: 'field5',
+        display: 'Field 5',
+        sortable: false,
+        type: 'string',
+        mandatory: false,
+        visible: false,
+      },
+      {
+        name: 'field6',
+        display: 'Field 6',
+        sortable: false,
+        type: 'HTML',
+        mandatory: false,
+        visible: true,
+      },
+      {
+        name: 'field7',
+        display: 'Field 7',
+        sortable: false,
+        visible: true,
+        type: 'date',
+        mandatory: false,
+      },
+    ],
+  },
+}
+
 module.exports = {
   report: {
     id: 'test-report-1',
@@ -1475,6 +1544,7 @@ module.exports = {
       variant10,
       variant11,
       variant12,
+      variant13,
     ],
   },
   reports: [
@@ -1494,6 +1564,7 @@ module.exports = {
         variant10,
         variant11,
         variant12,
+        variant13,
       ],
     },
   ],

--- a/test-app/mockAsyncData/mockReportListRenderData.js
+++ b/test-app/mockAsyncData/mockReportListRenderData.js
@@ -177,7 +177,7 @@ const mockGetReportListRenderData = {
         disabled: false,
         tooltipText: 'Refresh report',
         ariaLabelText: 'Refresh report',
-        href: 'fullUrl&refreshId=executionId',
+        href: 'fullUrl',
       },
       {
         id: 'dpr-button-printable',


### PR DESCRIPTION
https://dsdmoj.atlassian.net/jira/software/c/projects/DPR2/boards/1587?selectedIssue=DPR2-1005

- Remove Expired but refreshed reports from datastore
- Remove Failed but retried reports from datastore

Implementation:

- Checks the recentlyViewed store for duplicates and deletes them before adding the new one
- Checks the requestedReports store for duplicates and deletes them before adding the new one
- Removed need for retryId and refreshId

Bonus:

- Fixed a bug with expired functionality
- If sort columns is empty, don't show it
- If no filters are available don't show filters heading