### PR TITLE
min max defaults affect relative dates

### DIFF
--- a/src/dpr/components/async-filters/utils.ts
+++ b/src/dpr/components/async-filters/utils.ts
@@ -144,6 +144,7 @@ const getFiltersFromDefinition = (definition: components['schemas']['VariantDefi
       const { display: text, name, filter } = f
       const { type, staticOptions, dynamicOptions, defaultValue, mandatory, pattern } = filter
       const defaultMaxDate = '9999-01-01'
+      const defaultMinDate = '1977-05-25'
 
       let filterData: FilterValue = {
         text,
@@ -179,11 +180,12 @@ const getFiltersFromDefinition = (definition: components['schemas']['VariantDefi
         filterData = filterData as unknown as DateFilterValue
         filterData = {
           ...filterData,
-          min: filter.min,
+          min: filter.min || defaultMinDate,
           max: filter.max || defaultMaxDate,
           value,
-          relativeOptions: getRelativeDateOptions(min, max),
         }
+
+        filterData.relativeOptions = getRelativeDateOptions(filterData.min, filterData.max)
       }
 
       if (type === FilterType.date.toLowerCase()) {

--- a/src/dpr/components/date-input/view.njk
+++ b/src/dpr/components/date-input/view.njk
@@ -9,6 +9,15 @@
   {% set max = dateData.max %}
   {% set id = parameterPrefix + name + parameterSuffix %}
 
+  {% set defaultMinDate = '1977-05-25' %}
+  {% set defaultMaxDate = '9999-01-01'%}
+  {% if min ===  defaultMinDate %}
+    {% set toggleMin = false %}
+  {% endif %}
+  {% if max ===  defaultMaxDate %}
+    {% set toggleMax = false %}
+  {% endif %}
+
   {% if label %}
     {% set labelText = {
       text: label
@@ -52,7 +61,7 @@
         </a>
     {% endif %}
 
-    {% if toggleMax and max and max !== '9999-01-01' %}
+    {% if toggleMax and max %}
       <a class="govuk-body-xs daterange-set-to-minmax" 
           data-set-to-input='{{ id }}' 
           data-set-min-max-value={{ max }} 

--- a/src/dpr/components/date-range/clientClass.mjs
+++ b/src/dpr/components/date-range/clientClass.mjs
@@ -25,8 +25,6 @@ export default class DateRangeInput extends DprClientClass {
     this.datePickerTab = document.getElementById('tab_date-picker')
     this.relativeDurationTab = document.getElementById('tab_relative-range')
 
-    this.initialisedValue = this.dateRangeInputs.getAttribute('data-initialised-value')
-
     if (this.datePickerTab && this.relativeDurationTab) {
       this.initDatePickerTabClick()
       this.initRelativeDurationTabClick()
@@ -55,7 +53,6 @@ export default class DateRangeInput extends DprClientClass {
       this.queryParams = new URLSearchParams(window.location.search)
       if (this.queryParams.has(this.durationInputID)) {
         value = this.queryParams.get(this.durationInputID)
-        console.log(value)
         this.removeSearchParam(this.durationInputID)
       }
       this.updateInputs(value)

--- a/test-app/mockAsyncData/mockVariants/variant15.js
+++ b/test-app/mockAsyncData/mockVariants/variant15.js
@@ -18,8 +18,6 @@ const variant15 = {
         filter: {
           type: 'daterange',
           defaultValue: 'next-week',
-          min: '2003-02-01',
-          max: '2024-08-20',
           mandatory: true,
         },
       },


### PR DESCRIPTION
Bug fix for issue where relative range was calculated without using default min and max values. Therefore if no min max is set in the DPD then dayjs will set min and max to today to calc the relative duration. Meaning all relative durations will be disabled 

the fix: Use default min max values when calculating relative durations