### PR TITLE
sort list by product, then by variant

### DIFF
--- a/src/dpr/components/bookmark-toggle/clientClass.mjs
+++ b/src/dpr/components/bookmark-toggle/clientClass.mjs
@@ -59,7 +59,9 @@ export default class BookmarkToggle extends DprClientClass {
       }),
     })
       .then(() => {
-        window.location.reload()
+        if (!window.location.href.includes('/report')) {
+          window.location.reload()
+        }
       })
       .catch((error) => console.error('Error:', error))
   }

--- a/src/dpr/components/reports-list/utils.ts
+++ b/src/dpr/components/reports-list/utils.ts
@@ -18,30 +18,35 @@ export default {
     const { definitions, csrfToken } = res.locals
     const pathSuffix = res.locals.pathSuffix || ''
 
-    const allVariants = definitions.flatMap((def: components['schemas']['ReportDefinitionSummary']) => {
+    const sortedDefinitions = definitions.sort(
+      (a: components['schemas']['ReportDefinitionSummary'], b: components['schemas']['ReportDefinitionSummary']) => {
+        if (a.name < b.name) return -1
+        if (a.name > b.name) return 1
+        return 0
+      },
+    )
+
+    const sortedVariants = sortedDefinitions.flatMap((def: components['schemas']['ReportDefinitionSummary']) => {
       const { id: reportId, name: reportName, description: reportDescription } = def
       const { variants } = def
-      return variants.map((variant) => {
-        const { id: variantId, name: variantName, description: variantDescription } = variant
-        return {
-          reportName,
-          reportId,
-          variantId,
-          variantName,
-          variantDescription,
-          reportDescription,
-        }
-      })
-    })
 
-    const sortedVariants = allVariants.sort((a: variantData, b: variantData) => {
-      if (a.variantName < b.variantName) {
-        return -1
-      }
-      if (a.variantName > b.variantName) {
-        return 1
-      }
-      return 0
+      return variants
+        .map((variant) => {
+          const { id: variantId, name: variantName, description: variantDescription } = variant
+          return {
+            reportName,
+            reportId,
+            variantId,
+            variantName,
+            variantDescription,
+            reportDescription,
+          }
+        })
+        .sort((a: variantData, b: variantData) => {
+          if (a.variantName < b.variantName) return -1
+          if (a.variantName > b.variantName) return 1
+          return 0
+        })
     })
 
     const rows = sortedVariants.map((v: variantData) => {

--- a/test-app/mockAsyncData/mockReportDefinition.js
+++ b/test-app/mockAsyncData/mockReportDefinition.js
@@ -41,25 +41,23 @@ module.exports = {
   reports: [
     {
       id: 'test-report-1',
-      name: 'Test Report',
-      variants: [
-        variant1,
-        variant2,
-        variant3,
-        variant4,
-        variant5,
-        variant6,
-        variant7,
-        variant8,
-        variant9,
-        variant10,
-        variant11,
-        variant12,
-        variant13,
-        variant14,
-        variant15,
-        variant16,
-      ],
+      name: 'C Test Report',
+      variants: [variant1, variant2, variant3, variant4],
+    },
+    {
+      id: 'test-report-1',
+      name: 'D Test Report',
+      variants: [variant5, variant6, variant7],
+    },
+    {
+      id: 'test-report-2',
+      name: 'B Test Report',
+      variants: [variant8, variant9, variant10, variant11],
+    },
+    {
+      id: 'test-report-2',
+      name: 'A Test Report',
+      variants: [variant12, variant13, variant14, variant15, variant16],
     },
   ],
 }


### PR DESCRIPTION
Sort reports list alphabetically by product first, then by variant

Bonus: Fix bookmark toggle bug on report page