### PR TITLE
Fix Remove button for expired/failed reports

### DIFF
--- a/src/dpr/components/async-request-list/clientClass.mjs
+++ b/src/dpr/components/async-request-list/clientClass.mjs
@@ -62,7 +62,8 @@ export default class DprAsyncRequestList extends DprPollingStatusClass {
   initItemActions() {
     this.removeActions.forEach((button) => {
       const id = button.getAttribute('data-execution-id')
-      button.addEventListener('click', async () => {
+      button.addEventListener('click', async (e) => {
+        e.preventDefault()
         await this.removeItemFromList(id)
       })
     })

--- a/src/dpr/components/bookmark-toggle/clientClass.mjs
+++ b/src/dpr/components/bookmark-toggle/clientClass.mjs
@@ -10,7 +10,8 @@ export default class BookmarkToggle extends DprClientClass {
   }
 
   initToggles() {
-    document.querySelectorAll('.bookmark-input[type=checkbox]').forEach((bookmarkToggle) => {
+    const element = this.getElement()
+    element.querySelectorAll('.bookmark-input[type=checkbox]').forEach((bookmarkToggle) => {
       const csrfToken = bookmarkToggle.getAttribute('data-csrf-token')
       const reportId = bookmarkToggle.getAttribute('data-report-id')
       const variantId = bookmarkToggle.getAttribute('data-variant-id')

--- a/src/dpr/components/recently-viewed-list/clientClass.mjs
+++ b/src/dpr/components/recently-viewed-list/clientClass.mjs
@@ -40,7 +40,8 @@ export default class DprRecentlyViewedList extends DprPollingStatusClass {
   initItemActions() {
     this.removeActions.forEach((button) => {
       const id = button.getAttribute('data-execution-id')
-      button.addEventListener('click', async () => {
+      button.addEventListener('click', async (e) => {
+        e.preventDefault()
         await this.removeItemFromList(id)
       })
     })

--- a/src/dpr/components/reports-list/view.njk
+++ b/src/dpr/components/reports-list/view.njk
@@ -4,14 +4,12 @@
 {% macro dprReportsList(head, rows, id = 'reports-search') %}
 
   {% set tableHtml %}
-  <div data-dpr-module="bookmark-toggle">
     {{ govukTable({
       captionClasses: "govuk-table__caption--m",
       head: head,
       rows: rows,
       classes: "dpr-search-table"
     }) }}
-  </div>
   {% endset %}
 
   {{ dprSearch(id, tableHtml) }}

--- a/src/dpr/services/bookmarkService.ts
+++ b/src/dpr/services/bookmarkService.ts
@@ -59,7 +59,7 @@ export default class BookmarkService extends UserStoreService {
   createBookMarkToggleHtml(reportId: string, variantId: string, csrfToken: string, id: string) {
     const checked = this.isBookmarked(variantId) ? 'checked' : null
     const tooltip = !checked ? 'Add Bookmark' : 'Remove Bookmark'
-    return `<div class='dpr-bookmark dpr-bookmark-tooltip dpr-bookmark-table' tooltip="${tooltip}">
+    return `<div class='dpr-bookmark dpr-bookmark-tooltip dpr-bookmark-table' tooltip="${tooltip}" data-dpr-module="bookmark-toggle">
   <input class="bookmark-input" aria-label="bookmark toggle" type='checkbox' id='${reportId}-${variantId}-${id}' data-report-id='${reportId}' data-variant-id='${variantId}' data-csrf-token='${csrfToken}' ${checked} />
   <label id="${variantId}-${reportId}-bookmark-label" for='${reportId}-${variantId}-${id}'><span class="dpr-visually-hidden">Bookmark toggle</span></label>
 </div>`


### PR DESCRIPTION
https://dsdmoj.atlassian.net/browse/DPR2-1100

Remove button does not always work. 

Fix: as its an a tag - js needs to include `e.preventDefault` on click to stop the page reloading before the removal is complete

Bonus: Bookmark toggle works as standalone component thanks to `getElement` 