### PR TITLE
fix js by removing search text highligthing

### DIFF
--- a/src/dpr/components/search/clientClass.mjs
+++ b/src/dpr/components/search/clientClass.mjs
@@ -2,11 +2,11 @@
 import { DprClientClass } from '../../DprClientClass.mjs'
 
 export default class Search extends DprClientClass {
-  static getModuleName () {
+  static getModuleName() {
     return 'search'
   }
 
-  updateSearchListing (value) {
+  updateSearchListing(value) {
     const table = this.getElement().querySelector('table').querySelector('tbody')
 
     const rows = Array.from(table.rows)
@@ -15,26 +15,34 @@ export default class Search extends DprClientClass {
     const searchValue = value.toLowerCase()
 
     rows
-      .filter(
-        (row) =>
+      .filter((row) => {
+        return (
           !value ||
           value.length === 0 ||
-          Array.from(row.cells).find((cell) => cell.innerText.toLowerCase().includes(searchValue.toLowerCase())),
-      )
+          Array.from(row.cells).find((cell) => {
+            return cell.innerText.toLowerCase().includes(searchValue.toLowerCase())
+          })
+        )
+      })
       .forEach((row) => {
-        Array.from(row.cells).forEach((cell) => {
-          cell.innerHTML = cell.innerHTML.replace(/<\/?b>/gi, '')
+        // NOTE: Text highlighting functionality below breaks the client class JS. Causing bookmarking & showmore to break
 
-          if (searchValue) {
-            const text = cell.innerText.replaceAll(new RegExp(`(${searchValue})`, 'gi'), `<b>$1</b>`)
-            cell.innerHTML = cell.innerHTML.replace(cell.innerText, text)
-          }
-        })
+        // Array.from(row.cells).forEach((cell) => {
+        //   const innerHTMLContent = cell.innerHTML
+        //   cell.innerHTML = innerHTMLContent.replace(/<\/?b>/gi, '')
+
+        //   if (searchValue) {
+        //     const innerHTMLText = cell.innerText
+        //     const text = innerHTMLText.replaceAll(new RegExp(`(${searchValue})`, 'gi'), `<b>$1</b>`)
+        //     const innerHTMLCont = cell.innerHTML
+        //     cell.innerHTML = innerHTMLCont.replace(cell.innerText, text)
+        //   }
+        // })
         row.classList.remove('search-option-hide')
       })
   }
 
-  initialise () {
+  initialise() {
     const searchBox = this.getElement().querySelector('.dpr-search-box')
 
     if (searchBox) {

--- a/src/dpr/components/show-more/clientClass.mjs
+++ b/src/dpr/components/show-more/clientClass.mjs
@@ -18,7 +18,7 @@ export default class ShowMore extends DprClientClass {
     const shortString = textContent.replaceAll(/<[^>]+>/g, '').substring(0, length)
 
     if (textContent.length > length) {
-      textContainer.innerHTML = `${shortString}... `
+      textContainer.innerHTML = `${shortString}...`
     } else {
       textContainer.innerHTML = `${textContent}`
       button.style.display = 'none'

--- a/src/dpr/components/show-more/clientClass.mjs
+++ b/src/dpr/components/show-more/clientClass.mjs
@@ -18,7 +18,7 @@ export default class ShowMore extends DprClientClass {
     const shortString = textContent.replaceAll(/<[^>]+>/g, '').substring(0, length)
 
     if (textContent.length > length) {
-      textContainer.innerHTML = `${shortString}...`
+      textContainer.innerHTML = `${shortString}... `
     } else {
       textContainer.innerHTML = `${textContent}`
       button.style.display = 'none'

--- a/src/dpr/components/show-more/style.scss
+++ b/src/dpr/components/show-more/style.scss
@@ -2,5 +2,9 @@
   .dpr-show-hide-button {
     display: inline-block
   }
+
+  .dpr-show-more-content {
+    display: inline;
+  }
 }
  

--- a/src/dpr/utils/reportsListHelper.ts
+++ b/src/dpr/utils/reportsListHelper.ts
@@ -27,10 +27,11 @@ export const getMeta = (cardData: CardData[]) => {
 export const createShowMoreHtml = (text: string, length?: number) => {
   const sanitizedString = text ? text.replace(/"/g, "'") : ''
   const stringLength = length || 200
-  const displayString = sanitizedString.length <= stringLength ? sanitizedString : ''
 
   return `<div class="dpr-show-more" data-content="${sanitizedString}" data-dpr-module="show-more" data-length="${stringLength}">
-    <p class="govuk-body-s govuk-!-margin-bottom-0"><span class='dpr-show-more-content'>${displayString}</span><a class="dpr-show-hide-button" href="#">show more</a></p>
+    <p class="govuk-body-s govuk-!-margin-bottom-0">
+      <div class='dpr-show-more-content'>${sanitizedString}</div><a class="dpr-show-hide-button" href="#">show more</a>
+    </p>
   </div>`
 }
 


### PR DESCRIPTION
Filtered report rows after searching was killing JS for those rows. Eg, show more + bookmarking do not work on rows after performing a search.

This issue is caused by replacing the HTML in the table cells in the search functionality to highlight text, but why this causes it to fail, I don't know.

The PR suggests sacrificing the search term highlighting to get the JS working again. And a further investigation can be done to fix test highlighting without breaking the JS