### PR TITLE
use fragment + reload to log req in app insights

### DIFF
--- a/src/dpr/all.mjs
+++ b/src/dpr/all.mjs
@@ -9,6 +9,7 @@ import ToggleButton from './components/toggle-button/clientClass.mjs'
 import AsyncFilters from './components/async-filters/clientClass.mjs'
 import Pagination from './components/pagination/clientClass.mjs'
 import IconButtonList from './components/icon-button-list/clientClass.mjs'
+import ReportActions from './components/report-actions/clientClass.mjs'
 import DataTable from './components/data-table/clientClass.mjs'
 import AsyncPolling from './components/async-polling/clientClass.mjs'
 import Search from './components/search/clientClass.mjs'
@@ -25,6 +26,7 @@ import LineChartVisualisation from './components/chart/line/clientClass.mjs'
 import DownloadFeedbackForm from './components/download-feeback-form/cientClass.mjs'
 import LoadDashboard from './DprLoadDashboard.mjs'
 import ScoreCard from './components/scorecard/clientClass.mjs'
+import DownloadMessage from './components/download-message/clientClass.mjs'
 /**
  * Initialise all components
  *
@@ -59,6 +61,8 @@ export default function initAll() {
     LoadDashboard,
     DownloadFeedbackForm,
     ScoreCard,
+    ReportActions,
+    DownloadMessage,
   ]
 
   const customParseFormat = window.dayjs_plugin_customParseFormat

--- a/src/dpr/components/download-feeback-form/cientClass.mjs
+++ b/src/dpr/components/download-feeback-form/cientClass.mjs
@@ -27,9 +27,6 @@ export default class AsyncFilters extends DprFormValidationClass {
 
       if (this.mainForm.checkValidity()) {
         this.mainForm.requestSubmit()
-
-        this.success.classList.remove('download-feedback-form-success--hidden')
-        this.mainForm.classList.add('download-feedback-form--hidden')
       }
     })
   }

--- a/src/dpr/components/download-feeback-form/view.njk
+++ b/src/dpr/components/download-feeback-form/view.njk
@@ -3,7 +3,6 @@
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% from "govuk/components/panel/macro.njk" import govukPanel %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
 {% macro dprDownloadFeedbackForm(user, report, csrfToken) %}
@@ -16,19 +15,6 @@
   {% set csrfToken = csrfToken %}
 
   <div class="dpr-download-feedback-form-wrapper" data-dpr-module="download-feedback-form">
-
-    <div id="download-feedback-form-success" class="download-feedback-form-success--hidden">
-      {{ govukPanel({
-        titleText: "Your form has been submitted",
-        html: "Thank you for your feedback"
-      }) }}
-
-      {{ govukButton({
-        text: "Return to report",
-        classes: "govuk-button--primary govuk-!-margin-bottom-0",
-        href: '/async-reports/' + reportId + '/' + variantId + '/request/' + tableId + '/report'
-      }) }}
-    </div>
 
     <form action="/submitFeedback/" method="post" id="download-feedback-form" class="download-feedback-form--hidden">
       <p>Please take 5 minutes to fill out a feedback form and let us know why you would like to use the download feature</p>

--- a/src/dpr/components/download-message/clientClass.mjs
+++ b/src/dpr/components/download-message/clientClass.mjs
@@ -1,0 +1,14 @@
+import { DprClientClass } from '../../DprClientClass.mjs'
+
+export default class DownloadMessage extends DprClientClass {
+  static getModuleName() {
+    return 'download-message'
+  }
+
+  initialise() {
+    this.downloadMessage = this.getElement()
+    if (window.location.hash === '#download') {
+      this.downloadMessage.classList.remove('dpr-download-message--hidden')
+    }
+  }
+}

--- a/src/dpr/components/download-message/view.njk
+++ b/src/dpr/components/download-message/view.njk
@@ -17,7 +17,7 @@
     </a>
   {% endset %}
 
-  <div id="dpr-download-message" class="dpr-download-message--hidden govuk-!-margin-bottom-6">
+  <div id="dpr-download-message" class="dpr-download-message--hidden govuk-!-margin-bottom-6" data-dpr-module='download-message'>
     {{ mojTicketPanel({
       attributes: {
         'aria-label': 'Sub navigation 1'

--- a/src/dpr/components/report-actions/clientClass.mjs
+++ b/src/dpr/components/report-actions/clientClass.mjs
@@ -2,7 +2,7 @@ import { DprClientClass } from '../../DprClientClass.mjs'
 
 export default class IconButtonList extends DprClientClass {
   static getModuleName() {
-    return 'icon-button-list'
+    return 'report-actions'
   }
 
   initialise() {
@@ -69,12 +69,15 @@ export default class IconButtonList extends DprClientClass {
   }
 
   initDownloadButtonEvent() {
+    const hashFragment = 'download'
+    if (window.location.hash === `#${hashFragment}`) {
+      this.downloadButton.setAttribute('disabled', '')
+    }
+
     this.downloadButton.addEventListener('click', () => {
-      const downloadMessage = document.getElementById('dpr-download-message')
-      if (downloadMessage.classList.contains('dpr-download-message--hidden')) {
-        downloadMessage.classList.remove('dpr-download-message--hidden')
-      } else {
-        downloadMessage.classList.add('dpr-download-message--hidden')
+      if (window.location.hash !== `#${hashFragment}`) {
+        this.downloadButton.setAttribute('disabled', '')
+        this.setHashAndReload(hashFragment, true)
       }
     })
   }
@@ -91,6 +94,13 @@ export default class IconButtonList extends DprClientClass {
           window.location = href
         }
       })
+    }
+  }
+
+  setHashAndReload(hashFragment, reload) {
+    window.location.hash = hashFragment
+    if (reload) {
+      window.location.reload()
     }
   }
 }

--- a/src/dpr/components/report-actions/view.njk
+++ b/src/dpr/components/report-actions/view.njk
@@ -27,7 +27,7 @@
     {% endfor %}
 
   
-  <div class="report-actions" data-dpr-module='icon-button-list'>
+  <div class="report-actions" data-dpr-module='report-actions'>
     {{ mojButtonMenu({
       items: items
     }) }}

--- a/src/dpr/routes/download.ts
+++ b/src/dpr/routes/download.ts
@@ -35,9 +35,25 @@ export default function routes({
 
   const feedbackSubmitHandler: RequestHandler = async (req, res, next) => {
     const { body } = req
+    const { reportId, variantId, tableId } = body
     logger.info('Download Feedback Submission:', `${JSON.stringify(body)}`)
+    res.redirect(`/download/${reportId}/${variantId}/${tableId}/feedback/submitted`)
+  }
+
+  const feedbackSuccessHandler: RequestHandler = async (req, res, next) => {
+    const { reportId, variantId, tableId } = req.params
+    res.render(`${templatePath}feedback-form-success`, {
+      title: 'success',
+      layoutPath,
+      report: {
+        reportId,
+        variantId,
+        tableId,
+      },
+    })
   }
 
   router.get('/download/:reportId/:variantId/:tableId/feedback', feedbackFormHandler)
   router.post('/submitFeedback/', feedbackSubmitHandler)
+  router.get('/download/:reportId/:variantId/:tableId/feedback/submitted', feedbackSuccessHandler)
 }

--- a/src/dpr/views/feedback-form-success.njk
+++ b/src/dpr/views/feedback-form-success.njk
@@ -1,0 +1,21 @@
+
+{% extends layoutPath %}
+
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "../components/download-feeback-form/view.njk" import dprDownloadFeedbackForm %}
+
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block content %}
+  {{ govukPanel({
+    titleText: "Your form has been submitted",
+    html: "Thank you for your feedback"
+  }) }}
+
+  {{ govukButton({
+    text: "Return to report",
+    classes: "govuk-button--primary govuk-!-margin-bottom-0",
+    href: '/async-reports/' + report.reportId + '/' + report.variantId + '/request/' + report.tableId + '/report'
+  }) }}
+{% endblock %}


### PR DESCRIPTION
https://dsdmoj.atlassian.net/jira/software/c/projects/DPR2/boards/1345?quickFilter=4636&selectedIssue=DPR2-1082

App insights triggers for:

- download button - Adds hash fragment (#download )to URL and reloads page - new request should be logged in app insights. Route contains all report info needed, eg. reportID, variantId, tableId
- Feedback Submission - new success route. Should be logged in appInsights. Route also includes contains all report info needed, eg. reportID, variantId, tableId
