### PR TITLE
re-enabled download to test app insights in dev

### DIFF
--- a/src/dpr/components/report-actions/utils.ts
+++ b/src/dpr/components/report-actions/utils.ts
@@ -89,7 +89,7 @@ const initReportActions = ({
   // Downloadable
   // NOTE: Temporarily disabling for release 25
   // eslint-disable-next-line no-param-reassign
-  downloadable = false
+  // downloadable = false
   actions.push({
     ...BUTTON_TEMPLATES.downloadable,
     disabled: !downloadable,

--- a/test-app/mocks/mockAsyncData/mockReportListRenderData.js
+++ b/test-app/mocks/mockAsyncData/mockReportListRenderData.js
@@ -210,9 +210,9 @@ const mockGetReportListRenderData = {
       {
         id: 'dpr-button-downloadable',
         icon: 'download',
-        disabled: true,
+        disabled: false,
         tooltipText: 'Download',
-        ariaLabelText: 'Download report, disabled',
+        ariaLabelText: 'Download report',
       },
     ],
     querySummary: 'summary',


### PR DESCRIPTION
Temporarily re-enabling download button on reports so we can test that actions/events are being recorded correctly in appinsights

Will disable again after testing.