### PR TITLE
replaced hash fragment for route

### DIFF
--- a/src/dpr/components/download-message/clientClass.mjs
+++ b/src/dpr/components/download-message/clientClass.mjs
@@ -7,7 +7,7 @@ export default class DownloadMessage extends DprClientClass {
 
   initialise() {
     this.downloadMessage = this.getElement()
-    if (window.location.hash === '#download') {
+    if (window.location.href.indexOf('download') > -1) {
       this.downloadMessage.classList.remove('dpr-download-message--hidden')
     }
   }

--- a/src/dpr/components/report-actions/clientClass.mjs
+++ b/src/dpr/components/report-actions/clientClass.mjs
@@ -70,14 +70,14 @@ export default class IconButtonList extends DprClientClass {
 
   initDownloadButtonEvent() {
     const hashFragment = 'download'
-    if (window.location.hash === `#${hashFragment}`) {
+    if (window.location.href.indexOf(hashFragment) > -1) {
       this.downloadButton.setAttribute('disabled', '')
     }
 
     this.downloadButton.addEventListener('click', () => {
-      if (window.location.hash !== `#${hashFragment}`) {
+      if (window.location.href.indexOf(hashFragment) === -1) {
         this.downloadButton.setAttribute('disabled', '')
-        this.setHashAndReload(hashFragment, true)
+        window.location = `${window.location.pathname}/download${window.location.search}`
       }
     })
   }
@@ -94,13 +94,6 @@ export default class IconButtonList extends DprClientClass {
           window.location = href
         }
       })
-    }
-  }
-
-  setHashAndReload(hashFragment, reload) {
-    window.location.hash = hashFragment
-    if (reload) {
-      window.location.reload()
     }
   }
 }

--- a/src/dpr/routes/asyncReports.ts
+++ b/src/dpr/routes/asyncReports.ts
@@ -233,7 +233,11 @@ export default function routes({
   router.post('/cancelRequest/', cancelRequestHandler, asyncErrorHandler)
 
   // 3 - REPORT
-  router.get('/async/:type/:reportId/:id/request/:tableId/report', getReportHandler, asyncErrorHandler)
+  const viewReportPaths = [
+    '/async/:type/:reportId/:id/request/:tableId/report',
+    '/async/:type/:reportId/:id/request/:tableId/report/download',
+  ]
+  router.get(viewReportPaths, getReportHandler, asyncErrorHandler)
 
   // Homepage widget routes
   router.post('/removeRequestedItem/', removeRequestedItemHandler, asyncErrorHandler)


### PR DESCRIPTION
App insights does not log #fragments in urls. Currently, download clicks are recorded by using a hash fragment therefore app insights does not record this event.

Fixed by switching hash fragment to a route path