### PR TITLE
Datepicker fix

### DIFF
--- a/src/dpr/DprQueryParamClass.mjs
+++ b/src/dpr/DprQueryParamClass.mjs
@@ -69,8 +69,11 @@ export default class DprQueryParamClass extends DprClientClass {
       let { value } = input
 
       if (input.classList.contains('moj-js-datepicker-input')) {
-        const dateValue = dayjs(value, 'DD/MM/YYYY').format('YYYY-MM-DD')
-        value = dateValue !== 'Invalid date' ? dateValue : ''
+        let formatted = dayjs(value, 'DD/MM/YYYY').format('YYYY-MM-DD')
+        if (formatted === 'Invalid Date') {
+          formatted = dayjs(value, 'D/M/YYYY').format('YYYY-MM-DD')
+        }
+        value = formatted !== 'Invalid Date' ? formatted : ''
       }
 
       if (name) this.updateQueryParam(name, value)

--- a/src/dpr/DprQueryParamClass.mjs
+++ b/src/dpr/DprQueryParamClass.mjs
@@ -69,10 +69,7 @@ export default class DprQueryParamClass extends DprClientClass {
       let { value } = input
 
       if (input.classList.contains('moj-js-datepicker-input')) {
-        let formatted = dayjs(value, 'DD/MM/YYYY').format('YYYY-MM-DD')
-        if (formatted === 'Invalid Date') {
-          formatted = dayjs(value, 'D/M/YYYY').format('YYYY-MM-DD')
-        }
+        const formatted = dayjs(value, 'D/M/YYYY').format('YYYY-MM-DD')
         value = formatted !== 'Invalid Date' ? formatted : ''
       }
 


### PR DESCRIPTION
Dates being formatted using `DD/MM/YYYY' but the moj date picker does not include leading 0's when using the calendar selection. So a date of 8/8/2024 will fail formatting and return "Invalid Date".
