### PR TITLE
add pageSize to download data request

### DIFF
--- a/src/dpr/utils/downloadUtils.test.ts
+++ b/src/dpr/utils/downloadUtils.test.ts
@@ -62,6 +62,7 @@ describe('DownloadUtils', () => {
 
       reportingService = {
         getAsyncReport: jest.fn().mockResolvedValue(createMockData(10)),
+        getAsyncCount: jest.fn().mockResolvedValue(10),
         getDefinition: jest.fn().mockResolvedValue({
           variant: {
             specification: {

--- a/src/dpr/utils/downloadUtils.ts
+++ b/src/dpr/utils/downloadUtils.ts
@@ -85,8 +85,10 @@ export default {
         )
         reportData = listWithWarnings.data
       } else {
+        const pageSize = await services.reportingService.getAsyncCount(token, tableId)
         reportData = await services.reportingService.getAsyncReport(token, reportId, id, tableId, {
           dataProductDefinitionsPath,
+          pageSize,
         })
       }
 


### PR DESCRIPTION
the api to get async report data default to a pageSize of 10 when not provided. Therefore downloaded CSV only has 10 rows.

Fix: Add pageSize to API query