### PR TITLE
DPR2-1568 autocomplete to search full text of options

### DIFF
--- a/cypress-tests/integration-tests/features/autocomplete.feature
+++ b/cypress-tests/integration-tests/features/autocomplete.feature
@@ -15,6 +15,14 @@ Feature: Autocomplete
     When I enter text shorter than the minimum data length into the static Autocomplete box
     Then a list of options is not displayed
 
+  Scenario: Static autocomplete options show when the matching input text is not the prefix
+    When I enter text longer than the minimum data length into the static Autocomplete box which matches some of the options without being a prefix
+    Then a list of matching options is displayed
+
+  Scenario: Static autocomplete options are not displayed if the matching non prefix text is too short
+    When I enter text shorter than the minimum data length into the static Autocomplete box which matches some of the options without being a prefix
+    Then a list of options is not displayed
+
   Scenario: Static autocomplete options are selectable
     Given I enter text longer than the minimum data length into the static Autocomplete box
     When I select an autocomplete option

--- a/cypress-tests/integration-tests/step-definitions/autocomplete.ts
+++ b/cypress-tests/integration-tests/step-definitions/autocomplete.ts
@@ -4,7 +4,9 @@ import { Then, When } from '@badeball/cypress-cucumber-preprocessor'
 import ReportPage from '../pages/ReportPage'
 
 const shortMatchingText = 'Pr'
+const shortMatchingTextNonPrefix = 'in'
 const longMatchingText = 'Pri'
+const longMatchingTextNonPrefix = 'inc'
 const staticFieldName = 'field4'
 const dynamicFieldName = 'field5'
 
@@ -14,6 +16,18 @@ When(
   /^I enter text (longer|shorter) than the minimum data length into the (static|dynamic) Autocomplete box$/,
   function (this: Mocha.Context, length: string, type: string) {
     const text = length === 'longer' ? longMatchingText : shortMatchingText
+    const fieldName = getFieldNameFromType(type)
+
+    this.selectedFieldName = fieldName
+
+    new ReportPage().filter(fieldName).type(text)
+  },
+)
+
+When(
+  /^I enter text (longer|shorter) than the minimum data length into the (static|dynamic) Autocomplete box which matches some of the options without being a prefix$/,
+  function (this: Mocha.Context, length: string, type: string) {
+    const text = length === 'longer' ? longMatchingTextNonPrefix : shortMatchingTextNonPrefix
     const fieldName = getFieldNameFromType(type)
 
     this.selectedFieldName = fieldName

--- a/src/dpr/components/_inputs/autocomplete-text-input/clientClass.mjs
+++ b/src/dpr/components/_inputs/autocomplete-text-input/clientClass.mjs
@@ -51,7 +51,7 @@ export default class Autocomplete extends DprClientClass {
       this.getElement()
         .querySelectorAll(this.listItemsSelector)
         .forEach((item) => {
-          if (searchValue.length >= minLength && item.innerText.trim().toLowerCase().startsWith(searchValue)) {
+          if (searchValue.length >= minLength && item.innerText.trim().toLowerCase().includes(searchValue)) {
             item.classList.remove('autocomplete-text-input-item-hide')
           } else {
             item.classList.add('autocomplete-text-input-item-hide')


### PR DESCRIPTION
Currently the autocomplete search box tries to match only on the prefix of the available options.
The reason for this change is to replicate the functionality of legacy reports where the user can search the list of establishments when their input text matches either the establishment code or the description.