### PR TITLE
fixed mocked charts in the FE lib test app

### DIFF
--- a/src/dpr/components/_charts/chart-tabs/view.njk
+++ b/src/dpr/components/_charts/chart-tabs/view.njk
@@ -2,7 +2,7 @@
 {% from "govuk/components/tabs/macro.njk" import govukTabs %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 
-{% macro dprChartTabs(id, data, unit) %}
+{% macro dprChartTabs(id, data) %}
   {% set chartData = data.chart %}
   {% set tableData = data.table %}
 

--- a/src/dpr/components/_dashboards/dashboard/utils.ts
+++ b/src/dpr/components/_dashboards/dashboard/utils.ts
@@ -99,6 +99,8 @@ export default {
       UserReportsUtils.updateLastViewed({ services, reportStateData: dashboardRequestData, userId })
     }
 
+    console.log(JSON.stringify({ metrics }, null, 2))
+
     return {
       dashboardData: {
         token,

--- a/test-app/charts.njk
+++ b/test-app/charts.njk
@@ -1,8 +1,9 @@
 {% extends "page.njk" %}
 
-{% from "components/chart-card/view.njk" import dprChartCard %}
-{% from "components/chart-tabs/view.njk" import dprChartTabs %}
-{% from "components/chart/view.njk" import dprChart %}
+{% from "components/_charts/chart-card/view.njk" import dprChartCard %}
+{% from "components/_charts/chart-tabs/view.njk" import dprChartTabs %}
+{% from "components/_charts/chart/view.njk" import dprChart %}
+
 {% from "govuk/components/tabs/macro.njk" import govukTabs %}
 
 {% block content %}
@@ -25,10 +26,10 @@
         {{ dprChartCard(bar) }}
 
         <h2 class="govuk-heading-m dpr-dotted-unterline govuk-!-margin-bottom-6 govuk-!-margin-top-6">dprChartTabs component</h2>
-        {{ dprChartTabs(bar.id + "_", bar.type, bar.data) }}
+        {{ dprChartTabs(bar.id + "_", bar.data) }}
         
         <h2 class="govuk-heading-m dpr-dotted-unterline govuk-!-margin-bottom-6 govuk-!-margin-top-6">dprChart component</h2>
-        {{ dprChart(bar.id, bar.type[0], bar.data.chart)}}
+        {{ dprChart(bar.id, bar.data.chart[0].type, bar.data.chart[0].data, bar.data.chart[0].unit)}}
       </div>
     {% endfor %}
     {% endif %}
@@ -42,10 +43,10 @@
         {{ dprChartCard(pie) }}
 
         <h2 class="govuk-heading-m dpr-dotted-unterline govuk-!-margin-bottom-6 govuk-!-margin-top-6">dprChartTabs component</h2>
-        {{ dprChartTabs(pie.id + "_", pie.type, pie.data) }}
+        {{ dprChartTabs(pie.id + "_", pie.data) }}
 
         <h2 class="govuk-heading-m dpr-dotted-unterline govuk-!-margin-bottom-6 govuk-!-margin-top-6">dprChart component</h2>
-        {{ dprChart(pie.id, pie.type[0], pie.data.chart)}}
+        {{ dprChart(pie.id, pie.data.chart[0].type, pie.data.chart[0].data, pie.data.chart[0].unit)}}
       </div>
     {% endfor %}
     {% endif %}
@@ -59,10 +60,10 @@
         {{ dprChartCard(multi) }}
 
         <h2 class="govuk-heading-m dpr-dotted-unterline govuk-!-margin-bottom-6 govuk-!-margin-top-6">dprChartTabs component</h2>
-        {{ dprChartTabs(multi.id + "_", multi.type, multi.data) }}
+        {{ dprChartTabs(multi.id + "_", multi.data) }}
 
         <h2 class="govuk-heading-m dpr-dotted-unterline govuk-!-margin-bottom-6 govuk-!-margin-top-6">dprChart component</h2>
-        {{ dprChart(multi.id, multi.type[0], multi.data.chart)}}
+        {{ dprChart(multi.id, multi.data.chart[0].type, multi.data.chart[0].data, multi.data.chart[0].unit)}}
       </div>
     {% endfor %}
     {% endif %}
@@ -75,10 +76,10 @@
         {{ dprChartCard(line) }}
 
         <h2 class="govuk-heading-m dpr-dotted-unterline govuk-!-margin-bottom-6 govuk-!-margin-top-6">dprChartTabs component</h2>
-        {{ dprChartTabs(line.id + "_", line.type, line.data) }}
+        {{ dprChartTabs(line.id + "_", line.data) }}
 
         <h2 class="govuk-heading-m dpr-dotted-unterline govuk-!-margin-bottom-6 govuk-!-margin-top-6">dprChart component</h2>
-        {{ dprChart(line.id, line.type[0], line.data.chart)}}
+        {{ dprChart(line.id, line.data.chart[0].type, line.data.chart[0].data, line.data.chart[0].unit)}}
       </div>
     {% endfor %}
     {% endif %}

--- a/test-app/mocks/mockChartData/mockBarChartData.js
+++ b/test-app/mocks/mockChartData/mockBarChartData.js
@@ -3,7 +3,6 @@ const mockBarChartData = [
     id: 'bar-chart-1',
     title: 'Prisoners favourite colours',
     description: 'Prisoners favourite colours',
-    type: ['bar'],
     details: {
       headlines: [],
       meta: [
@@ -18,17 +17,23 @@ const mockBarChartData = [
       ],
     },
     data: {
-      chart: {
-        labels: ['Red', 'Blue', 'Yellow', 'Green', 'Purple', 'Orange'],
-        datasets: [
-          {
-            label: 'No of prisoners',
-            data: [12, 19, 3, 5, 2, 10],
-            total: [12, 19, 3, 5, 2, 10].reduce((acc, val) => acc + val, 0),
+      chart: [
+        {
+          type: 'bar',
+          unit: 'number',
+          data: {
+            labels: ['Red', 'Blue', 'Yellow', 'Green', 'Purple', 'Orange'],
+            datasets: [
+              {
+                label: 'No of prisoners',
+                data: [12, 19, 3, 5, 2, 10],
+                total: [12, 19, 3, 5, 2, 10].reduce((acc, val) => acc + val, 0),
+              },
+            ],
+            axis: 'x',
           },
-        ],
-        axis: 'x',
-      },
+        },
+      ],
       table: {
         head: [{ text: 'Colours' }, { text: 'No of prisoners' }],
         rows: [
@@ -46,7 +51,6 @@ const mockBarChartData = [
     id: 'bar-chart-2',
     title: 'Prisoners and Staff favourite colours',
     description: 'Prisoners and Staff favourite colours',
-    type: ['bar'],
     details: {
       headlines: [],
       meta: [
@@ -61,22 +65,28 @@ const mockBarChartData = [
       ],
     },
     data: {
-      chart: {
-        labels: ['Red', 'Blue', 'Yellow', 'Green', 'Purple', 'Orange'],
-        datasets: [
-          {
-            label: 'No of prisoners',
-            data: [12, 19, 3, 5, 2, 10],
-            total: [12, 19, 3, 5, 2, 10].reduce((acc, val) => acc + val, 0),
+      chart: [
+        {
+          type: 'bar',
+          unit: 'number',
+          data: {
+            labels: ['Red', 'Blue', 'Yellow', 'Green', 'Purple', 'Orange'],
+            datasets: [
+              {
+                label: 'No of prisoners',
+                data: [12, 19, 3, 5, 2, 10],
+                total: [12, 19, 3, 5, 2, 10].reduce((acc, val) => acc + val, 0),
+              },
+              {
+                label: 'No of Staff',
+                data: [17, 10, 6, 9, 6, 8],
+                total: [17, 10, 6, 9, 6, 8].reduce((acc, val) => acc + val, 0),
+              },
+            ],
+            axis: 'x',
           },
-          {
-            label: 'No of Staff',
-            data: [17, 10, 6, 9, 6, 8],
-            total: [17, 10, 6, 9, 6, 8].reduce((acc, val) => acc + val, 0),
-          },
-        ],
-        axis: 'x',
-      },
+        },
+      ],
       table: {
         head: [{ text: 'Colours' }, { text: 'No of prisoners' }, { text: 'No of Staff' }],
         rows: [
@@ -94,7 +104,6 @@ const mockBarChartData = [
     id: 'bar-chart-3',
     title: 'Prisoners and Staff favourite colours',
     description: 'Prisoners and Staff favourite colours',
-    type: ['bar'],
     details: {
       headlines: [],
       meta: [
@@ -109,23 +118,29 @@ const mockBarChartData = [
       ],
     },
     data: {
-      chart: {
-        labels: ['Red', 'Blue', 'Yellow', 'Green', 'Purple', 'Orange'],
-        datasets: [
-          {
-            label: 'No of Prisoners',
-            data: [12, 19, 3, 5, 2, 10],
-            total: [12, 19, 3, 5, 2, 10].reduce((acc, val) => acc + val, 0),
+      chart: [
+        {
+          type: 'bar',
+          unit: 'number',
+          data: {
+            labels: ['Red', 'Blue', 'Yellow', 'Green', 'Purple', 'Orange'],
+            datasets: [
+              {
+                label: 'No of Prisoners',
+                data: [12, 19, 3, 5, 2, 10],
+                total: [12, 19, 3, 5, 2, 10].reduce((acc, val) => acc + val, 0),
+              },
+              {
+                label: 'No of Staff',
+                data: [17, 10, 6, 9, 6, 8],
+                total: [17, 10, 6, 9, 6, 8].reduce((acc, val) => acc + val, 0),
+              },
+            ],
+            axis: 'x',
+            stacked: true,
           },
-          {
-            label: 'No of Staff',
-            data: [17, 10, 6, 9, 6, 8],
-            total: [17, 10, 6, 9, 6, 8].reduce((acc, val) => acc + val, 0),
-          },
-        ],
-        axis: 'x',
-        stacked: true,
-      },
+        },
+      ],
       table: {
         head: [{ text: 'Colours' }, { text: 'No of Prisoners' }, { text: 'No of Staff' }],
         rows: [
@@ -143,7 +158,6 @@ const mockBarChartData = [
     id: 'bar-chart-4',
     title: 'Prisoners and Staff and pets favourite colours',
     description: 'Prisoners and Staff and pets favourite colours',
-    type: ['bar'],
     details: {
       headlines: [],
       meta: [
@@ -158,27 +172,33 @@ const mockBarChartData = [
       ],
     },
     data: {
-      chart: {
-        labels: ['Red', 'Blue', 'Yellow', 'Green', 'Purple', 'Orange'],
-        datasets: [
-          {
-            label: 'No of Prisoners',
-            data: [12, 19, 3, 5, 2, 10],
-            total: [12, 19, 3, 5, 2, 10].reduce((acc, val) => acc + val, 0),
+      chart: [
+        {
+          type: 'bar',
+          unit: 'number',
+          data: {
+            labels: ['Red', 'Blue', 'Yellow', 'Green', 'Purple', 'Orange'],
+            datasets: [
+              {
+                label: 'No of Prisoners',
+                data: [12, 19, 3, 5, 2, 10],
+                total: [12, 19, 3, 5, 2, 10].reduce((acc, val) => acc + val, 0),
+              },
+              {
+                label: 'No of Staff',
+                data: [17, 10, 6, 9, 6, 8],
+                total: [17, 10, 6, 9, 6, 8].reduce((acc, val) => acc + val, 0),
+              },
+              {
+                label: 'No of Pets',
+                data: [17, 10, 6, 5, 12, 8],
+                total: [17, 10, 6, 5, 12, 8].reduce((acc, val) => acc + val, 0),
+              },
+            ],
+            axis: 'x',
           },
-          {
-            label: 'No of Staff',
-            data: [17, 10, 6, 9, 6, 8],
-            total: [17, 10, 6, 9, 6, 8].reduce((acc, val) => acc + val, 0),
-          },
-          {
-            label: 'No of Pets',
-            data: [17, 10, 6, 5, 12, 8],
-            total: [17, 10, 6, 5, 12, 8].reduce((acc, val) => acc + val, 0),
-          },
-        ],
-        axis: 'x',
-      },
+        },
+      ],
       table: {
         head: [{ text: 'Colours' }, { text: 'No of Prisoners' }, { text: 'No of Staff' }],
         rows: [

--- a/test-app/mocks/mockChartData/mockLineChartData.js
+++ b/test-app/mocks/mockChartData/mockLineChartData.js
@@ -10,7 +10,6 @@ const mockLineChartData = [
     id: 'line-chart-1',
     title: 'Assaults on Staff',
     description: 'Total assaults on staff',
-    type: ['line'],
     details: {
       headlines: [],
       meta: [
@@ -25,16 +24,22 @@ const mockLineChartData = [
       ],
     },
     data: {
-      chart: {
-        labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
-        datasets: [
-          {
-            label: 'Assaults',
-            data: lineChartData[0],
-            total: lineChartData[0].reduce((a, c) => a + c, 0),
+      chart: [
+        {
+          type: 'line',
+          unit: 'number',
+          data: {
+            labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+            datasets: [
+              {
+                label: 'Assaults',
+                data: lineChartData[0],
+                total: lineChartData[0].reduce((a, c) => a + c, 0),
+              },
+            ],
           },
-        ],
-      },
+        },
+      ],
     },
   },
   {
@@ -56,21 +61,27 @@ const mockLineChartData = [
       ],
     },
     data: {
-      chart: {
-        labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
-        datasets: [
-          {
-            label: 'Assaults',
-            data: lineChartData[2],
-            total: lineChartData[2].reduce((a, c) => a + c, 0),
+      chart: [
+        {
+          type: 'line',
+          unit: 'number',
+          data: {
+            labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+            datasets: [
+              {
+                label: 'Assaults',
+                data: lineChartData[2],
+                total: lineChartData[2].reduce((a, c) => a + c, 0),
+              },
+              {
+                label: 'Serious',
+                data: lineChartData[3],
+                total: lineChartData[3].reduce((a, c) => a + c, 0),
+              },
+            ],
           },
-          {
-            label: 'Serious',
-            data: lineChartData[3],
-            total: lineChartData[3].reduce((a, c) => a + c, 0),
-          },
-        ],
-      },
+        },
+      ],
     },
   },
   {
@@ -92,31 +103,37 @@ const mockLineChartData = [
       ],
     },
     data: {
-      chart: {
-        labels: ['Jan 21', 'Jan 22', 'jan 23'],
-        datasets: [
-          {
-            label: 'Cutting',
-            data: [20, 50, 60],
-            total: [20, 50, 60].reduce((a, c) => a + c, 0),
+      chart: [
+        {
+          type: 'line',
+          unit: 'number',
+          data: {
+            labels: ['Jan 21', 'Jan 22', 'jan 23'],
+            datasets: [
+              {
+                label: 'Cutting',
+                data: [20, 50, 60],
+                total: [20, 50, 60].reduce((a, c) => a + c, 0),
+              },
+              {
+                label: 'Suffocation',
+                data: [10, 34, 40],
+                total: [10, 34, 40].reduce((a, c) => a + c, 0),
+              },
+              {
+                label: 'Ingestion',
+                data: [4, 16, 23],
+                total: [4, 16, 23].reduce((a, c) => a + c, 0),
+              },
+              {
+                label: 'Other',
+                data: [2, 4, 8],
+                total: [2, 4, 8].reduce((a, c) => a + c, 0),
+              },
+            ],
           },
-          {
-            label: 'Suffocation',
-            data: [10, 34, 40],
-            total: [10, 34, 40].reduce((a, c) => a + c, 0),
-          },
-          {
-            label: 'Ingestion',
-            data: [4, 16, 23],
-            total: [4, 16, 23].reduce((a, c) => a + c, 0),
-          },
-          {
-            label: 'Other',
-            data: [2, 4, 8],
-            total: [2, 4, 8].reduce((a, c) => a + c, 0),
-          },
-        ],
-      },
+        },
+      ],
     },
   },
 ]

--- a/test-app/mocks/mockChartData/mockMultiChartData.js
+++ b/test-app/mocks/mockChartData/mockMultiChartData.js
@@ -18,16 +18,36 @@ const mockBarChartData = [
       ],
     },
     data: {
-      chart: {
-        labels: ['Drugs', 'Phones', 'Weapons', 'Alcohol'],
-        datasets: [
-          {
-            label: 'No. of finds',
-            data: [12, 19, 3, 5],
-            total: [12, 19, 3, 5].reduce((acc, val) => acc + val, 0),
+      chart: [
+        {
+          type: 'bar',
+          unit: 'number',
+          data: {
+            labels: ['Drugs', 'Phones', 'Weapons', 'Alcohol'],
+            datasets: [
+              {
+                label: 'No. of finds',
+                data: [12, 19, 3, 5],
+                total: [12, 19, 3, 5].reduce((acc, val) => acc + val, 0),
+              },
+            ],
           },
-        ],
-      },
+        },
+        {
+          type: 'doughnut',
+          unit: 'number',
+          data: {
+            labels: ['Drugs', 'Phones', 'Weapons', 'Alcohol'],
+            datasets: [
+              {
+                label: 'No. of finds',
+                data: [12, 19, 3, 5],
+                total: [12, 19, 3, 5].reduce((acc, val) => acc + val, 0),
+              },
+            ],
+          },
+        },
+      ],
       table: {
         head: [{ text: 'Colours' }, { text: 'No. of finds' }],
         rows: [
@@ -64,16 +84,36 @@ const mockBarChartData = [
       ],
     },
     data: {
-      chart: {
-        labels: ['Drugs', 'Phones', 'Weapons', 'Alcohol'],
-        datasets: [
-          {
-            label: 'No. of finds',
-            data: [12, 19, 3, 5],
-            total: [12, 19, 3, 5].reduce((acc, val) => acc + val, 0),
+      chart: [
+        {
+          type: 'bar',
+          unit: 'number',
+          data: {
+            labels: ['Drugs', 'Phones', 'Weapons', 'Alcohol'],
+            datasets: [
+              {
+                label: 'No. of finds',
+                data: [12, 19, 3, 5],
+                total: [12, 19, 3, 5].reduce((acc, val) => acc + val, 0),
+              },
+            ],
           },
-        ],
-      },
+        },
+        {
+          type: 'doughnut',
+          unit: 'number',
+          data: {
+            labels: ['Drugs', 'Phones', 'Weapons', 'Alcohol'],
+            datasets: [
+              {
+                label: 'No. of finds',
+                data: [12, 19, 3, 5],
+                total: [12, 19, 3, 5].reduce((acc, val) => acc + val, 0),
+              },
+            ],
+          },
+        },
+      ],
       table: {
         head: [{ text: 'Colours' }, { text: 'No. of finds' }],
         rows: [
@@ -113,21 +153,46 @@ const mockBarChartData = [
       ],
     },
     data: {
-      chart: {
-        labels: ['General', 'Serious'],
-        datasets: [
-          {
-            label: 'On Staff',
-            data: [60, 70],
-            total: [60, 70].reduce((acc, val) => acc + val, 0),
+      chart: [
+        {
+          type: 'bar',
+          unit: 'number',
+          data: {
+            labels: ['General', 'Serious'],
+            datasets: [
+              {
+                label: 'On Staff',
+                data: [60, 70],
+                total: [60, 70].reduce((acc, val) => acc + val, 0),
+              },
+              {
+                label: 'On Prisoner',
+                data: [18, 50],
+                total: [18, 50].reduce((acc, val) => acc + val, 0),
+              },
+            ],
           },
-          {
-            label: 'On Prisoner',
-            data: [18, 50],
-            total: [18, 50].reduce((acc, val) => acc + val, 0),
+        },
+        {
+          type: 'doughnut',
+          unit: 'number',
+          data: {
+            labels: ['General', 'Serious'],
+            datasets: [
+              {
+                label: 'On Staff',
+                data: [60, 70],
+                total: [60, 70].reduce((acc, val) => acc + val, 0),
+              },
+              {
+                label: 'On Prisoner',
+                data: [18, 50],
+                total: [18, 50].reduce((acc, val) => acc + val, 0),
+              },
+            ],
           },
-        ],
-      },
+        },
+      ],
       table: {
         head: [{ text: 'Colours' }, { text: 'On Staff' }, { text: 'On Prisoner' }],
         rows: [

--- a/test-app/mocks/mockChartData/mockPieChartData.js
+++ b/test-app/mocks/mockChartData/mockPieChartData.js
@@ -18,16 +18,22 @@ const mockBarChartData = [
       ],
     },
     data: {
-      chart: {
-        labels: ['Red Red RedRed Red', 'Blue', 'Yellow', 'Green', 'Purple', 'Orange'],
-        datasets: [
-          {
-            label: 'No of prisoners',
-            data: [12, 19, 3, 5, 2, 10],
-            total: [12, 19, 3, 5, 2, 10].reduce((acc, val) => acc + val, 0),
+      chart: [
+        {
+          type: 'doughnut',
+          unit: 'number',
+          data: {
+            labels: ['Red Red RedRed Red', 'Blue', 'Yellow', 'Green', 'Purple', 'Orange'],
+            datasets: [
+              {
+                label: 'No of prisoners',
+                data: [12, 19, 3, 5, 2, 10],
+                total: [12, 19, 3, 5, 2, 10].reduce((acc, val) => acc + val, 0),
+              },
+            ],
           },
-        ],
-      },
+        },
+      ],
       table: {
         head: [{ text: 'Colours' }, { text: 'No of prisoners' }],
         rows: [
@@ -60,21 +66,27 @@ const mockBarChartData = [
       ],
     },
     data: {
-      chart: {
-        labels: ['Red', 'Blue', 'Yellow', 'Green'],
-        datasets: [
-          {
-            label: 'No of prisoners',
-            data: [12, 19, 3, 5],
-            total: [12, 19, 3, 5].reduce((acc, val) => acc + val, 0),
+      chart: [
+        {
+          type: 'doughnut',
+          unit: 'number',
+          data: {
+            labels: ['Red', 'Blue', 'Yellow', 'Green'],
+            datasets: [
+              {
+                label: 'No of prisoners',
+                data: [12, 19, 3, 5],
+                total: [12, 19, 3, 5].reduce((acc, val) => acc + val, 0),
+              },
+              {
+                label: 'No of Staff',
+                data: [17, 10, 6, 9],
+                total: [17, 10, 6, 9].reduce((acc, val) => acc + val, 0),
+              },
+            ],
           },
-          {
-            label: 'No of Staff',
-            data: [17, 10, 6, 9],
-            total: [17, 10, 6, 9].reduce((acc, val) => acc + val, 0),
-          },
-        ],
-      },
+        },
+      ],
       table: {
         head: [{ text: 'Colours' }, { text: 'No of prisoners' }, { text: 'No of Staff' }],
         rows: [


### PR DESCRIPTION
The mocked charts in the FE lib test app had be left behind after the recent data structure changes. This PR brings it upto date