### PR TITLE
DPR2-1611 fix autocomplete issue for async

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@ministryofjustice/frontend": "^3.0.3",
         "agentkeepalive": "^4.5.0",
         "bunyan": "^1.8.15",
         "bunyan-format": "^0.2.1",
@@ -30,7 +31,6 @@
         "@axe-core/cli": "^4.10.0",
         "@badeball/cypress-cucumber-preprocessor": "^18.0.6",
         "@bahmutov/cypress-esbuild-preprocessor": "^2.2.0",
-        "@ministryofjustice/frontend": "^3.0.3",
         "@semantic-release/git": "^10.0.1",
         "@semantic-release/npm": "^11.0.0",
         "@types/bunyan": "^1.8.8",
@@ -3319,7 +3319,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-3.1.0.tgz",
       "integrity": "sha512-Dp2xqgXNM2om56EQdjNXaEKju3k330sTRoXNMEQEHI2qYTSwyz67VW3PkUHrWH1BXE7E2MyU/Q3OVA6ZhcZBsA==",
-      "dev": true,
       "dependencies": {
         "govuk-frontend": "^5.0.0",
         "moment": "^2.27.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@ministryofjustice/frontend": "^3.0.3",
         "agentkeepalive": "^4.5.0",
         "bunyan": "^1.8.15",
         "bunyan-format": "^0.2.1",
@@ -31,6 +30,7 @@
         "@axe-core/cli": "^4.10.0",
         "@badeball/cypress-cucumber-preprocessor": "^18.0.6",
         "@bahmutov/cypress-esbuild-preprocessor": "^2.2.0",
+        "@ministryofjustice/frontend": "^3.0.3",
         "@semantic-release/git": "^10.0.1",
         "@semantic-release/npm": "^11.0.0",
         "@types/bunyan": "^1.8.8",
@@ -3319,6 +3319,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-3.1.0.tgz",
       "integrity": "sha512-Dp2xqgXNM2om56EQdjNXaEKju3k330sTRoXNMEQEHI2qYTSwyz67VW3PkUHrWH1BXE7E2MyU/Q3OVA6ZhcZBsA==",
+      "dev": true,
       "dependencies": {
         "govuk-frontend": "^5.0.0",
         "moment": "^2.27.0"

--- a/src/dpr/components/_async/async-filters-form/utils.ts
+++ b/src/dpr/components/_async/async-filters-form/utils.ts
@@ -99,7 +99,7 @@ export default {
     let querySummary: Array<Dict<string>> = []
     const sortData: Dict<string> = {}
     const dateMapper = new DateMapper()
-
+    const urlParams = new URLSearchParams(req.body.search)
     Object.keys(req.body)
       .filter((name) => name !== '_csrf' && req.body[name] !== '')
       .forEach((name) => {
@@ -118,8 +118,8 @@ export default {
         }
 
         if (name.startsWith('filters.') && value !== '' && !query[name]) {
-          query[name as keyof Dict<string>] = value
-          filterData[shortName as keyof Dict<string>] = value
+          query[name as keyof Dict<string>] = urlParams.get(name) || value
+          filterData[shortName as keyof Dict<string>] = urlParams.get(name) || value
 
           let dateDisplayValue
 
@@ -134,7 +134,7 @@ export default {
           const fieldDisplayName = DefinitionUtils.getFieldDisplayName(fields, shortName)
           querySummary.push({
             name: fieldDisplayName || shortName,
-            value: dateDisplayValue || value,
+            value: dateDisplayValue || urlParams.get(name) || value,
           })
         } else if (name.startsWith('sort')) {
           query[name as keyof Dict<string>] = value

--- a/test-app/mocks/mockClients/reports/mockVariants/variant4.js
+++ b/test-app/mocks/mockClients/reports/mockVariants/variant4.js
@@ -69,7 +69,7 @@ const variant4 = {
             returnAsStaticOptions: true,
           },
           staticOptions: [
-            { name: 'Fezzick', display: 'Fezzick' },
+            { name: 'Fez', display: 'Fezzick' },
             { name: 'Inigo Montoya', display: 'Inigo Montoya' },
             { name: 'Prince Humperdink', display: 'Prince Humperdink' },
             { name: 'Princess Buttercup', display: 'Princess Buttercup' },


### PR DESCRIPTION
These changes fix the issue in which the autocomplete name value was not passed but instead the display values was passed when the "Request Report button" was clicked and the form submitted in the async journey.
This was despite the URL having the correct values as query parameters.