### PR TITLE
Interactive reports fixes

### DIFF
--- a/src/dpr/components/_filters/filters-selected/utils.ts
+++ b/src/dpr/components/_filters/filters-selected/utils.ts
@@ -4,7 +4,17 @@ import { FilterValue, DateRange, DateFilterValue } from '../types'
 
 const getSelectedFilters = (filters: FilterValue[], prefix: string) => {
   return filters
-    .filter((f) => f.value)
+    .filter((f) => {
+      return (
+        (f.value &&
+          Object.prototype.hasOwnProperty.call(f.value, 'start') &&
+          (<DateRange>f.value).start !== undefined) ||
+        (f.value && Object.prototype.hasOwnProperty.call(f.value, 'end') && (<DateRange>f.value).end !== undefined) ||
+        (f.value &&
+          !Object.prototype.hasOwnProperty.call(f.value, 'start') &&
+          !Object.prototype.hasOwnProperty.call(f.value, 'end'))
+      )
+    })
     .map((f) => {
       let value: (string | DateRange)[] = []
       let key: string[] = []

--- a/src/dpr/components/_filters/utils.ts
+++ b/src/dpr/components/_filters/utils.ts
@@ -67,14 +67,17 @@ export const handleDateValue = (filter: FilterValue, req: Request, prefix: strin
  * @param {components['schemas']['VariantDefinition']} definition
  * @return {*}
  */
-const getFiltersFromDefinition = (fields: components['schemas']['FieldDefinition'][], interactive = false) => {
+const getFiltersFromDefinition = (fields: components['schemas']['FieldDefinition'][], interactive?: boolean) => {
   return fields
     .filter((f) => f.filter)
     .filter((f) => {
       // TODO: fix types here once it has been defined.
-      return interactive
-        ? (<components['schemas']['FieldDefinition'] & { interactive?: boolean }>f.filter).interactive
-        : !(<components['schemas']['FieldDefinition'] & { interactive?: boolean }>f.filter).interactive
+      if (interactive !== undefined) {
+        return interactive
+          ? (<components['schemas']['FieldDefinition'] & { interactive?: boolean }>f.filter).interactive
+          : !(<components['schemas']['FieldDefinition'] & { interactive?: boolean }>f.filter).interactive
+      }
+      return true
     })
     .map((f) => {
       const { display: text, name, filter } = f

--- a/src/dpr/components/_reports/report-template/view.njk
+++ b/src/dpr/components/_reports/report-template/view.njk
@@ -12,10 +12,6 @@
   {% set reportSummaries = renderData.reportSummaries %}
   {% set count = renderData.count %}
 
-  {% if not count or count === 0 %}
-    {{ dprReportNoDataMessage(url) }}
-  {% else %}
-
     <div class="report-template-container  {% if (printable == false) %}print-hide{% endif %}">
       {% if template === 'list-tab' or template === 'crosstab' %}
 
@@ -23,20 +19,28 @@
 
       {% elif template === 'list-section' or template === 'summary-section' %}
 
-        {{ dprReport(renderData) }}
+        {{ dprReport(renderData, count) }}
 
       {% elif template === 'summary' %}
 
-        {{ dprReportSummary(reportSummaries, 'page-header') }}
-        {{ dprReportSummary(reportSummaries, 'page-footer') }}
+        {% if not count or count === 0 %}
+          {{ dprReportNoDataMessage(url) }}
+        {% else %}
+
+          {{ dprReportSummary(reportSummaries, 'page-header') }}
+          {{ dprReportSummary(reportSummaries, 'page-footer') }}
+
+        {% endif %}
 
       {% else %}
 
-        {{ dprReport(renderData) }}
-        {{ dprReportPagination(pagination) }}
+        {{ dprReport(renderData, count) }}
+
+        {% if count and count === 0 %}
+          {{ dprReportPagination(pagination) }}
+        {% endif %}
 
       {% endif %}
     </div>
 
-  {% endif %}
 {% endmacro %}

--- a/src/dpr/components/_reports/report-template/view.njk
+++ b/src/dpr/components/_reports/report-template/view.njk
@@ -36,7 +36,7 @@
 
         {{ dprReport(renderData, count) }}
 
-        {% if count and count === 0 %}
+        {% if count and count > 0 %}
           {{ dprReportPagination(pagination) }}
         {% endif %}
 

--- a/src/dpr/components/_reports/report/view.njk
+++ b/src/dpr/components/_reports/report/view.njk
@@ -3,30 +3,39 @@
 {% from "../report-summary-table/view.njk" import dprReportSummary %}
 {% from "../report-totals/view.njk" import dprReportTotals %}
 {% from "../report-filters/view.njk" import dprReportFilters %}
+{% from "../report-no-data-message/view.njk" import dprReportNoDataMessage %}
 
 {% from "../../_filters/filters-interactive/view.njk" import dprInteractiveFilters %}
 
-{% macro dprReport(options) %}
+{% macro dprReport(options, count) %}
   {% set columns = options.columns %}
   {% set reportSummaries = options.reportSummaries %}
   {% set filterData = options.filterData %}
 
   <div class="dpr-sync-report-actions">
     {{ dprReportFilters(filterData) }}
-    {{ dprReportColumns(columns) }}
+    {% if count and count > 0 %}
+      {{ dprReportColumns(columns) }}
+    {% endif %}
   </div>
 
-  {{ dprReportSummary(reportSummaries, 'page-header') }}
-  {{ dprReportTotals(options.totals) }}
+  {% if not count or count === 0 %}
+    {{ dprReportNoDataMessage(url) }}
+  {% else %}
 
-  <div class='dpr-table-container'>
-    {{ dprDataTable(options) }}
-  </div>
-  
-  <div class='govuk-!-margin-bottom-6'>
+    {{ dprReportSummary(reportSummaries, 'page-header') }}
     {{ dprReportTotals(options.totals) }}
-  </div>
-  
-  {{ dprReportSummary(reportSummaries, 'page-footer') }}
+
+    <div class='dpr-table-container'>
+      {{ dprDataTable(options) }}
+    </div>
+    
+    <div class='govuk-!-margin-bottom-6'>
+      {{ dprReportTotals(options.totals) }}
+    </div>
+    
+    {{ dprReportSummary(reportSummaries, 'page-footer') }}
+
+  {% endif %}
 
 {% endmacro %}

--- a/src/dpr/components/_sync/sync-report/utils.ts
+++ b/src/dpr/components/_sync/sync-report/utils.ts
@@ -201,7 +201,6 @@ const getReportRenderData = async (
   const filterData = await FiltersUtils.getFilters({
     fields: specification.fields,
     req,
-    interactive: false,
   })
 
   const columns = ColumnUtils.getColumns(specification, reportQuery.columns)


### PR DESCRIPTION
Interactive filters fixes

- If a report has no data, the "no data" message removes the interactive filters stopping users from using them.
- Selected filters included daterange if value.start & value.end attributes exist but the value is undefined.
- Report should show both interactive & non-interactive filters on the report if no interactive flag exists - for sync reports 