### PR TITLE
DPR2-1614 Filter on staticOptions name value or display value

### DIFF
--- a/cypress-tests/integration-tests/features/autocomplete.feature
+++ b/cypress-tests/integration-tests/features/autocomplete.feature
@@ -15,10 +15,6 @@ Feature: Autocomplete
     When I enter text shorter than the minimum data length into the static Autocomplete box
     Then a list of options is not displayed
 
-  Scenario: Static autocomplete options show when the matching input text is not the prefix
-    When I enter text longer than the minimum data length into the static Autocomplete box which matches some of the options without being a prefix
-    Then a list of matching options is displayed
-
   Scenario: Static autocomplete options are not displayed if the matching non prefix text is too short
     When I enter text shorter than the minimum data length into the static Autocomplete box which matches some of the options without being a prefix
     Then a list of options is not displayed
@@ -35,12 +31,16 @@ Feature: Autocomplete
     Then the selected option is displayed in the URL
     And the select option is displayed in the Selected Filters section
 
-  Scenario: Static autocomplete filter option name values are submitted
-    Given I enter text into the static Autocomplete box which matches an option which has different name and display values
+  Scenario Outline: Static autocomplete filter option name values are submitted
+    Given I enter "<text>" into the static Autocomplete box which matches an option which has different name and display values
     And I select an autocomplete option
     When I apply the filters
     Then the name value of the selected option is displayed in the URL
     And the display value of the selected option is displayed in the Selected Filters section
+    Examples:
+        |text    |
+        |prb     |
+        |princes |
 
   Scenario: Dynamic autocomplete filter is displayed
     Then the dynamic Autocomplete box is shown

--- a/cypress-tests/integration-tests/features/autocomplete.feature
+++ b/cypress-tests/integration-tests/features/autocomplete.feature
@@ -15,10 +15,6 @@ Feature: Autocomplete
     When I enter text shorter than the minimum data length into the static Autocomplete box
     Then a list of options is not displayed
 
-  Scenario: Static autocomplete options are not displayed if the matching non prefix text is too short
-    When I enter text shorter than the minimum data length into the static Autocomplete box which matches some of the options without being a prefix
-    Then a list of options is not displayed
-
   Scenario: Static autocomplete options are selectable
     Given I enter text longer than the minimum data length into the static Autocomplete box
     When I select an autocomplete option

--- a/cypress-tests/integration-tests/step-definitions/autocomplete.ts
+++ b/cypress-tests/integration-tests/step-definitions/autocomplete.ts
@@ -1,12 +1,10 @@
 /* eslint-disable func-names */
 
-import { Then, When } from '@badeball/cypress-cucumber-preprocessor'
+import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor'
 import ReportPage from '../pages/ReportPage'
 
 const shortMatchingText = 'Pr'
-const shortMatchingTextNonPrefix = 'in'
 const longMatchingText = 'Pri'
-const longMatchingTextNonPrefix = 'inc'
 const staticFieldName = 'field4'
 const dynamicFieldName = 'field5'
 
@@ -24,27 +22,14 @@ When(
   },
 )
 
-When(
-  /^I enter text (longer|shorter) than the minimum data length into the (static|dynamic) Autocomplete box which matches some of the options without being a prefix$/,
-  function (this: Mocha.Context, length: string, type: string) {
-    const text = length === 'longer' ? longMatchingTextNonPrefix : shortMatchingTextNonPrefix
-    const fieldName = getFieldNameFromType(type)
-
-    this.selectedFieldName = fieldName
-
-    new ReportPage().filter(fieldName).type(text)
-  },
-)
-
-When(
-  /^I enter text into the static Autocomplete box which matches an option which has different name and display values$/,
-  function (this: Mocha.Context) {
-    const text = 'but'
+Given(
+  'I enter {string} into the static Autocomplete box which matches an option which has different name and display values',
+  function (this: Mocha.Context, string: string) {
     const fieldName = getFieldNameFromType('static')
 
-    this.selectedFieldName = fieldName
+    // this.selectedFieldName = fieldName
 
-    new ReportPage().filter(fieldName).type(text)
+    new ReportPage().filter(fieldName).type(string)
   },
 )
 

--- a/cypress-tests/integration-tests/step-definitions/autocomplete.ts
+++ b/cypress-tests/integration-tests/step-definitions/autocomplete.ts
@@ -26,9 +26,7 @@ Given(
   'I enter {string} into the static Autocomplete box which matches an option which has different name and display values',
   function (this: Mocha.Context, string: string) {
     const fieldName = getFieldNameFromType('static')
-
-    // this.selectedFieldName = fieldName
-
+    this.selectedFieldName = fieldName
     new ReportPage().filter(fieldName).type(string)
   },
 )

--- a/src/dpr/DprQueryParamClass.mjs
+++ b/src/dpr/DprQueryParamClass.mjs
@@ -68,13 +68,13 @@ export default class DprQueryParamClass extends DprClientClass {
       } else {
         const { name } = input
         let { value } = input
-        let { staticOptionValue } = input
+        let { staticOptionNameValue } = input
         let isDateInput = input.classList.contains('moj-js-datepicker-input')
         if (isDateInput) {
           const formatted = dayjs(value, 'D/M/YYYY').format('YYYY-MM-DD')
           value = formatted !== 'Invalid Date' ? formatted : ''
         }
-        let valueToUpdate = !isDateInput && staticOptionValue ? staticOptionValue : value
+        let valueToUpdate = !isDateInput && staticOptionNameValue ? staticOptionNameValue : value
         if (name) this.updateQueryParam(name, valueToUpdate)
       }
     }

--- a/src/dpr/components/_inputs/autocomplete-text-input/clientClass.mjs
+++ b/src/dpr/components/_inputs/autocomplete-text-input/clientClass.mjs
@@ -51,7 +51,8 @@ export default class Autocomplete extends DprClientClass {
       this.getElement()
         .querySelectorAll(this.listItemsSelector)
         .forEach((item) => {
-          if (searchValue.length >= minLength && item.innerText.trim().toLowerCase().includes(searchValue)) {
+          if (searchValue.length >= minLength &&
+            this.isMatchingStaticOptionValueOrTextInputPrefix(this.getInputListButton(item), searchValue, item)) {
             item.classList.remove('autocomplete-text-input-item-hide')
           } else {
             item.classList.add('autocomplete-text-input-item-hide')
@@ -63,6 +64,19 @@ export default class Autocomplete extends DprClientClass {
       const changeEvent = new Event('change')
       textInput.dispatchEvent(changeEvent)
     }
+  }
+
+  getInputListButton(item) {
+    return item.querySelector('.autocomplete-text-input-list-button')
+  }
+
+  isMatchingStaticOptionValueOrTextInputPrefix(inputListButton, searchValue, item) {
+    return this.isStaticOptionsValuePrefix(inputListButton.dataset.staticOptionValue, searchValue)
+      || item.innerText.trim().toLowerCase().startsWith(searchValue)
+  }
+
+  isStaticOptionsValuePrefix(staticOptionValue, searchValue) {
+    return staticOptionValue && staticOptionValue.trim().toLowerCase().startsWith(searchValue)
   }
 
   async populateOptionsDynamically(resourceEndpoint, searchValue, textInput, templateProvider) {

--- a/src/dpr/components/_inputs/autocomplete-text-input/clientClass.mjs
+++ b/src/dpr/components/_inputs/autocomplete-text-input/clientClass.mjs
@@ -52,7 +52,7 @@ export default class Autocomplete extends DprClientClass {
         .querySelectorAll(this.listItemsSelector)
         .forEach((item) => {
           if (searchValue.length >= minLength &&
-            this.isMatchingStaticOptionValueOrTextInputPrefix(this.getInputListButton(item), searchValue, item)) {
+            this.isMatchingStaticOptionNameOrDisplayPrefix(this.getInputListButton(item), searchValue, item)) {
             item.classList.remove('autocomplete-text-input-item-hide')
           } else {
             item.classList.add('autocomplete-text-input-item-hide')
@@ -70,13 +70,13 @@ export default class Autocomplete extends DprClientClass {
     return item.querySelector('.autocomplete-text-input-list-button')
   }
 
-  isMatchingStaticOptionValueOrTextInputPrefix(inputListButton, searchValue, item) {
-    return this.isStaticOptionsValuePrefix(inputListButton.dataset.staticOptionValue, searchValue)
+  isMatchingStaticOptionNameOrDisplayPrefix(inputListButton, searchValue, item) {
+    return this.isStaticOptionsNamePrefix(inputListButton.dataset.staticOptionNameValue, searchValue)
       || item.innerText.trim().toLowerCase().startsWith(searchValue)
   }
 
-  isStaticOptionsValuePrefix(staticOptionValue, searchValue) {
-    return staticOptionValue && staticOptionValue.trim().toLowerCase().startsWith(searchValue)
+  isStaticOptionsNamePrefix(staticOptionNameValue, searchValue) {
+    return staticOptionNameValue && staticOptionNameValue.trim().toLowerCase().startsWith(searchValue)
   }
 
   async populateOptionsDynamically(resourceEndpoint, searchValue, textInput, templateProvider) {
@@ -102,7 +102,7 @@ export default class Autocomplete extends DprClientClass {
     event.preventDefault()
     // eslint-disable-next-line no-param-reassign
     textInput.value = event.target.innerText.trim()
-    textInput.staticOptionValue = event.target.dataset.staticOptionValue
+    textInput.staticOptionNameValue = event.target.dataset.staticOptionNameValue
     textInput.focus()
     const changeEvent = new Event('change')
     textInput.dispatchEvent(changeEvent)

--- a/src/dpr/components/_inputs/autocomplete-text-input/view.njk
+++ b/src/dpr/components/_inputs/autocomplete-text-input/view.njk
@@ -69,7 +69,7 @@
                                 classes: "govuk-button--inverse autocomplete-text-input-list-button",
                                 attributes: {
                                     "data-parent-input": options.id,
-                                    "data-static-option-value": item.value
+                                    "data-static-option-name-value": item.value
                                 }
                             }) }}
                         </li>

--- a/src/dpr/components/filters/clientClass.mjs
+++ b/src/dpr/components/filters/clientClass.mjs
@@ -45,8 +45,8 @@ export default class Filters extends DprClientClass {
       const formData = new FormData(filtersForm)
       let serializedFormData = ''
       document.querySelectorAll('.autocomplete-text-input-box').forEach((input) => {
-        if(input.staticOptionValue) {
-          formData.set(input.name, input.staticOptionValue)
+        if(input.staticOptionNameValue) {
+          formData.set(input.name, input.staticOptionNameValue)
         }
       })
       formData.forEach((v, n) => {


### PR DESCRIPTION
These changes:
- Change back the autocomplete search as it was initially. i.e. to search the prefix instead of the full text.
- Allow searching the prefix of either the static options name value or the display value of the list of static options.
- Renamed staticOptionsValue to staticOptionsNameValue to avoid confusion and be more precise.