### PR TITLE
Dpr2 947 date inclusivity check

### DIFF
--- a/src/dpr/components/_inputs/granular-date-range/clientClass.mjs
+++ b/src/dpr/components/_inputs/granular-date-range/clientClass.mjs
@@ -68,52 +68,107 @@ export default class GranularDateRangeInput extends DprClientClass {
     switch (quickFilterValue) {
       case 'today':
         endDate = dayjs()
-        startDate = endDate.subtract(1, 'day')
+        startDate = dayjs()
+        granularity = 'daily'
+        break
+      case 'yesterday':
+        endDate = dayjs().subtract(1, 'day')
+        startDate = dayjs().subtract(1, 'day')
         granularity = 'daily'
         break
       case 'last-seven-days':
         endDate = dayjs()
-        startDate = endDate.subtract(1, 'week')
+        startDate = endDate.subtract(1, 'week').add(1, 'day')
         granularity = 'daily'
         break
       case 'last-thirty-days':
         endDate = dayjs()
-        startDate = endDate.subtract(1, 'month')
+        startDate = endDate.subtract(1, 'month').add(1, 'day')
         granularity = 'daily'
         break
       case 'last-month':
         endDate = dayjs()
-        startDate = endDate.subtract(1, 'month')
+        startDate = endDate.subtract(1, 'month').add(1, 'day')
         granularity = 'monthly'
         break
       case 'last-full-month':
         endDate = dayjs().subtract(1, 'month').endOf('month')
-        startDate = endDate.subtract(1, 'month')
+        startDate = endDate.startOf('month')
         granularity = 'monthly'
         break
       case 'last-90-days':
         endDate = dayjs()
-        startDate = endDate.subtract(3, 'month')
+        startDate = endDate.subtract(3, 'month').add(1, 'day')
         granularity = 'daily'
         break
       case 'last-3-months':
         endDate = dayjs()
-        startDate = endDate.subtract(3, 'month')
+        startDate = endDate.subtract(3, 'month').add(1, 'day')
         granularity = 'monthly'
         break
       case 'last-full-3-months':
         endDate = dayjs().subtract(1, 'month').endOf('month')
-        startDate = endDate.subtract(3, 'month')
+        startDate = endDate.subtract(2, 'month').startOf('month')
         granularity = 'monthly'
         break
       case 'last-year':
         endDate = dayjs()
-        startDate = endDate.subtract(1, 'year')
+        startDate = endDate.subtract(1, 'year').add(1, 'day')
         granularity = 'annually'
         break
       case 'last-full-year':
         endDate = dayjs().subtract(1, 'year').endOf('year')
-        startDate = endDate.subtract(1, 'year')
+        startDate = endDate.startOf('year')
+        granularity = 'annually'
+        break
+      case 'tomorrow':
+        endDate = dayjs().add(1, 'day')
+        startDate = dayjs().add(1, 'day')
+        granularity = 'daily'
+        break
+      case 'next-seven-days':
+        startDate = dayjs()
+        endDate = dayjs().add(7, 'day').subtract(1, 'day')
+        granularity = 'daily'
+        break
+      case 'next-thirty-days':
+        startDate = dayjs()
+        endDate = dayjs().add(1, 'month').subtract(1, 'day')
+        granularity = 'daily'
+        break
+      case 'next-month':
+        startDate = dayjs()
+        endDate = dayjs().add(1, 'month').subtract(1, 'day')
+        granularity = 'monthly'
+        break
+      case 'next-full-month':
+        startDate = dayjs().add(1, 'month').startOf('month')
+        endDate = startDate.endOf('month')
+        granularity = 'monthly'
+        break
+      case 'next-90-days':
+        startDate = dayjs()
+        endDate = dayjs().add(3, 'month').subtract(1, 'day')
+        granularity = 'daily'
+        break
+      case 'next-3-months':
+        startDate = dayjs()
+        endDate = dayjs().add(3, 'month').subtract(1, 'day')
+        granularity = 'monthly'
+        break
+      case 'next-full-3-months':
+        startDate = dayjs().add(1, 'month').startOf('month')
+        endDate = startDate.add(2, 'month').endOf('month')
+        granularity = 'monthly'
+        break
+      case 'next-year':
+        startDate = dayjs()
+        endDate = dayjs().add(1, 'year').subtract(1, 'day')
+        granularity = 'annually'
+        break
+      case 'next-full-year':
+        startDate = dayjs().add(1, 'year').startOf('year')
+        endDate = startDate.endOf('year')
         granularity = 'annually'
         break
       default:

--- a/src/dpr/components/_inputs/granular-date-range/utils.test.ts
+++ b/src/dpr/components/_inputs/granular-date-range/utils.test.ts
@@ -22,7 +22,7 @@ describe('GranularDatePickerUtils', () => {
       const result = GranularDatePickerUtils.getFilterFromDefinition(filter, {} as unknown as FilterValue)
 
       expect(result.value).toEqual({
-        start: '2024-06-05',
+        start: '2024-06-06',
         end: '2024-06-06',
         granularity: {
           value: 'daily',
@@ -44,7 +44,7 @@ describe('GranularDatePickerUtils', () => {
       const result = GranularDatePickerUtils.getFilterFromDefinition(filter, {} as unknown as FilterValue)
 
       expect(result.value).toEqual({
-        start: '2024-05-30',
+        start: '2024-05-31',
         end: '2024-06-06',
         granularity: {
           value: 'daily',
@@ -66,7 +66,7 @@ describe('GranularDatePickerUtils', () => {
       const result = GranularDatePickerUtils.getFilterFromDefinition(filter, {} as unknown as FilterValue)
 
       expect(result.value).toEqual({
-        start: '2024-05-06',
+        start: '2024-05-07',
         end: '2024-06-06',
         granularity: {
           value: 'daily',
@@ -88,7 +88,7 @@ describe('GranularDatePickerUtils', () => {
       const result = GranularDatePickerUtils.getFilterFromDefinition(filter, {} as unknown as FilterValue)
 
       expect(result.value).toEqual({
-        start: '2024-05-06',
+        start: '2024-05-07',
         end: '2024-06-06',
         granularity: {
           value: 'monthly',
@@ -110,7 +110,7 @@ describe('GranularDatePickerUtils', () => {
       const result = GranularDatePickerUtils.getFilterFromDefinition(filter, {} as unknown as FilterValue)
 
       expect(result.value).toEqual({
-        start: '2024-04-30',
+        start: '2024-05-01',
         end: '2024-05-31',
         granularity: {
           value: 'monthly',
@@ -132,7 +132,7 @@ describe('GranularDatePickerUtils', () => {
       const result = GranularDatePickerUtils.getFilterFromDefinition(filter, {} as unknown as FilterValue)
 
       expect(result.value).toEqual({
-        start: '2024-03-06',
+        start: '2024-03-07',
         end: '2024-06-06',
         granularity: {
           value: 'daily',
@@ -154,7 +154,7 @@ describe('GranularDatePickerUtils', () => {
       const result = GranularDatePickerUtils.getFilterFromDefinition(filter, {} as unknown as FilterValue)
 
       expect(result.value).toEqual({
-        start: '2024-03-06',
+        start: '2024-03-07',
         end: '2024-06-06',
         granularity: {
           value: 'monthly',
@@ -176,7 +176,7 @@ describe('GranularDatePickerUtils', () => {
       const result = GranularDatePickerUtils.getFilterFromDefinition(filter, {} as unknown as FilterValue)
 
       expect(result.value).toEqual({
-        start: '2024-02-29',
+        start: '2024-03-01',
         end: '2024-05-31',
         granularity: {
           value: 'monthly',
@@ -198,7 +198,7 @@ describe('GranularDatePickerUtils', () => {
       const result = GranularDatePickerUtils.getFilterFromDefinition(filter, {} as unknown as FilterValue)
 
       expect(result.value).toEqual({
-        start: '2023-06-06',
+        start: '2023-06-07',
         end: '2024-06-06',
         granularity: {
           value: 'annually',
@@ -220,7 +220,7 @@ describe('GranularDatePickerUtils', () => {
       const result = GranularDatePickerUtils.getFilterFromDefinition(filter, {} as unknown as FilterValue)
 
       expect(result.value).toEqual({
-        start: '2022-12-31',
+        start: '2023-01-01',
         end: '2023-12-31',
         granularity: {
           value: 'annually',
@@ -229,6 +229,226 @@ describe('GranularDatePickerUtils', () => {
         quickFilter: {
           value: 'last-full-year',
           display: 'Last full year',
+        },
+      })
+    })
+
+    it('should get the filter from the definition and set the value - tomorrow', () => {
+      const filter = {
+        type: 'granulardaterange',
+        defaultValue: 'tomorrow',
+      } as unknown as components['schemas']['FilterDefinition'] & { defaultGranularity: string }
+
+      const result = GranularDatePickerUtils.getFilterFromDefinition(filter, {} as unknown as FilterValue)
+
+      expect(result.value).toEqual({
+        start: '2024-06-07',
+        end: '2024-06-07',
+        granularity: {
+          value: 'daily',
+          display: 'Daily',
+        },
+        quickFilter: {
+          value: 'tomorrow',
+          display: 'Tomorrow',
+        },
+      })
+    })
+
+    it('should get the filter from the definition and set the value - next-seven-days', () => {
+      const filter = {
+        type: 'granulardaterange',
+        defaultValue: 'next-seven-days',
+      } as unknown as components['schemas']['FilterDefinition'] & { defaultGranularity: string }
+
+      const result = GranularDatePickerUtils.getFilterFromDefinition(filter, {} as unknown as FilterValue)
+
+      expect(result.value).toEqual({
+        start: '2024-06-06',
+        end: '2024-06-12',
+        granularity: {
+          value: 'daily',
+          display: 'Daily',
+        },
+        quickFilter: {
+          value: 'next-seven-days',
+          display: 'Next 7 days',
+        },
+      })
+    })
+
+    it('should get the filter from the definition and set the value - next-thirty-days', () => {
+      const filter = {
+        type: 'granulardaterange',
+        defaultValue: 'next-thirty-days',
+      } as unknown as components['schemas']['FilterDefinition'] & { defaultGranularity: string }
+
+      const result = GranularDatePickerUtils.getFilterFromDefinition(filter, {} as unknown as FilterValue)
+
+      expect(result.value).toEqual({
+        start: '2024-06-06',
+        end: '2024-07-05',
+        granularity: {
+          value: 'daily',
+          display: 'Daily',
+        },
+        quickFilter: {
+          value: 'next-thirty-days',
+          display: 'Next 30 days',
+        },
+      })
+    })
+
+    it('should get the filter from the definition and set the value - next-month', () => {
+      const filter = {
+        type: 'granulardaterange',
+        defaultValue: 'next-month',
+      } as unknown as components['schemas']['FilterDefinition'] & { defaultGranularity: string }
+
+      const result = GranularDatePickerUtils.getFilterFromDefinition(filter, {} as unknown as FilterValue)
+
+      expect(result.value).toEqual({
+        start: '2024-06-06',
+        end: '2024-07-05',
+        granularity: {
+          value: 'monthly',
+          display: 'Monthly',
+        },
+        quickFilter: {
+          value: 'next-month',
+          display: 'Next month',
+        },
+      })
+    })
+
+    it('should get the filter from the definition and set the value - next-full-month', () => {
+      const filter = {
+        type: 'granulardaterange',
+        defaultValue: 'next-full-month',
+      } as unknown as components['schemas']['FilterDefinition'] & { defaultGranularity: string }
+
+      const result = GranularDatePickerUtils.getFilterFromDefinition(filter, {} as unknown as FilterValue)
+
+      expect(result.value).toEqual({
+        start: '2024-07-01',
+        end: '2024-07-31',
+        granularity: {
+          value: 'monthly',
+          display: 'Monthly',
+        },
+        quickFilter: {
+          value: 'next-full-month',
+          display: 'Next full month',
+        },
+      })
+    })
+
+    it('should get the filter from the definition and set the value - next-90-days', () => {
+      const filter = {
+        type: 'granulardaterange',
+        defaultValue: 'next-90-days',
+      } as unknown as components['schemas']['FilterDefinition'] & { defaultGranularity: string }
+
+      const result = GranularDatePickerUtils.getFilterFromDefinition(filter, {} as unknown as FilterValue)
+
+      expect(result.value).toEqual({
+        start: '2024-06-06',
+        end: '2024-09-05',
+        granularity: {
+          value: 'daily',
+          display: 'Daily',
+        },
+        quickFilter: {
+          value: 'next-90-days',
+          display: 'Next 90 days',
+        },
+      })
+    })
+
+    it('should get the filter from the definition and set the value - next-3-months', () => {
+      const filter = {
+        type: 'granulardaterange',
+        defaultValue: 'next-3-months',
+      } as unknown as components['schemas']['FilterDefinition'] & { defaultGranularity: string }
+
+      const result = GranularDatePickerUtils.getFilterFromDefinition(filter, {} as unknown as FilterValue)
+
+      expect(result.value).toEqual({
+        start: '2024-06-06',
+        end: '2024-09-05',
+        granularity: {
+          value: 'monthly',
+          display: 'Monthly',
+        },
+        quickFilter: {
+          value: 'next-3-months',
+          display: 'Next 3 months',
+        },
+      })
+    })
+
+    it('should get the filter from the definition and set the value - next-full-3-months', () => {
+      const filter = {
+        type: 'granulardaterange',
+        defaultValue: 'next-full-3-months',
+      } as unknown as components['schemas']['FilterDefinition'] & { defaultGranularity: string }
+
+      const result = GranularDatePickerUtils.getFilterFromDefinition(filter, {} as unknown as FilterValue)
+
+      expect(result.value).toEqual({
+        start: '2024-07-01',
+        end: '2024-09-30',
+        granularity: {
+          value: 'monthly',
+          display: 'Monthly',
+        },
+        quickFilter: {
+          value: 'next-full-3-months',
+          display: 'Next full 3 months',
+        },
+      })
+    })
+
+    it('should get the filter from the definition and set the value - next-year', () => {
+      const filter = {
+        type: 'granulardaterange',
+        defaultValue: 'next-year',
+      } as unknown as components['schemas']['FilterDefinition'] & { defaultGranularity: string }
+
+      const result = GranularDatePickerUtils.getFilterFromDefinition(filter, {} as unknown as FilterValue)
+
+      expect(result.value).toEqual({
+        start: '2024-06-06',
+        end: '2025-06-05',
+        granularity: {
+          value: 'annually',
+          display: 'Annually',
+        },
+        quickFilter: {
+          value: 'next-year',
+          display: 'Next year',
+        },
+      })
+    })
+
+    it('should get the filter from the definition and set the value - next-full-year', () => {
+      const filter = {
+        type: 'granulardaterange',
+        defaultValue: 'next-full-year',
+      } as unknown as components['schemas']['FilterDefinition'] & { defaultGranularity: string }
+
+      const result = GranularDatePickerUtils.getFilterFromDefinition(filter, {} as unknown as FilterValue)
+
+      expect(result.value).toEqual({
+        start: '2025-01-01',
+        end: '2025-12-31',
+        granularity: {
+          value: 'annually',
+          display: 'Annually',
+        },
+        quickFilter: {
+          value: 'next-full-year',
+          display: 'Next full year',
         },
       })
     })

--- a/src/dpr/components/_inputs/granular-date-range/utils.ts
+++ b/src/dpr/components/_inputs/granular-date-range/utils.ts
@@ -9,6 +9,8 @@ const getQuickFilterOptions = () => {
   const options: { value: string; text: string; disabled?: boolean }[] = [
     { value: 'none', text: 'None' },
     { value: 'today', text: 'Today' },
+    { value: 'past', text: 'Past:', disabled: true },
+    { value: 'yesterday', text: 'Yesterday' },
     { value: 'last-seven-days', text: 'Last 7 days' },
     { value: 'last-thirty-days', text: 'Last 30 days' },
     { value: 'last-month', text: 'Last month' },
@@ -18,6 +20,17 @@ const getQuickFilterOptions = () => {
     { value: 'last-full-3-months', text: 'Last full 3 months' },
     { value: 'last-year', text: 'Last year' },
     { value: 'last-full-year', text: 'Last full year' },
+    { value: 'future', text: 'Future:', disabled: true },
+    { value: 'tomorrow', text: 'Tomorrow' },
+    { value: 'next-seven-days', text: 'Next 7 days' },
+    { value: 'next-thirty-days', text: 'Next 30 days' },
+    { value: 'next-month', text: 'Next month' },
+    { value: 'next-full-month', text: 'Next full month' },
+    { value: 'next-90-days', text: 'Next 90 days' },
+    { value: 'next-3-months', text: 'Next 3 months' },
+    { value: 'next-full-3-months', text: 'Next full 3 months' },
+    { value: 'next-year', text: 'Next year' },
+    { value: 'next-full-year', text: 'Next full year' },
   ]
 
   return options
@@ -44,17 +57,22 @@ const setDateRangeFromQuickFilterValue = (value: string) => {
   switch (value) {
     case 'today':
       endDate = dayjs()
-      startDate = endDate.subtract(1, 'day')
+      startDate = dayjs()
+      granularity = 'daily'
+      break
+    case 'yesterday':
+      endDate = dayjs().subtract(1, 'day')
+      startDate = dayjs().subtract(1, 'day')
       granularity = 'daily'
       break
     case 'last-seven-days':
       endDate = dayjs()
-      startDate = endDate.subtract(1, 'week')
+      startDate = endDate.subtract(1, 'week').add(1, 'day')
       granularity = 'daily'
       break
     case 'last-thirty-days':
       endDate = dayjs()
-      startDate = endDate.subtract(1, 'month')
+      startDate = endDate.subtract(30, 'days')
       granularity = 'daily'
       break
     case 'last-month':
@@ -89,6 +107,43 @@ const setDateRangeFromQuickFilterValue = (value: string) => {
       break
     case 'last-full-year':
       endDate = dayjs().subtract(1, 'year').endOf('year')
+      startDate = endDate.subtract(1, 'year')
+      granularity = 'annually'
+      break
+    case 'tomorrow':
+      endDate = dayjs().add(1, 'day')
+      startDate = dayjs().add(1, 'day')
+      granularity = 'daily'
+      break
+    case 'next-seven-days':
+      startDate = dayjs()
+      endDate = dayjs().add(7, 'day')
+      granularity = 'daily'
+      break
+    case 'next-thirty-days':
+      startDate = dayjs()
+      endDate = dayjs().add(30, 'day')
+      granularity = 'daily'
+      break
+    case 'next-month':
+      startDate = dayjs()
+      endDate = dayjs().add(30, 'day')
+      granularity = 'monthly'
+      break
+    case 'next-90-days':
+      startDate = dayjs()
+      endDate = dayjs().add(90, 'day')
+      granularity = 'daily'
+      break
+    case 'next-3-months':
+      startDate = dayjs()
+      endDate = dayjs().add(3, 'month')
+      startDate = endDate.subtract(3, 'month')
+      granularity = 'monthly'
+      break
+    case 'next-year':
+      startDate = dayjs()
+      endDate = dayjs().add(1, 'year')
       startDate = endDate.subtract(1, 'year')
       granularity = 'annually'
       break

--- a/src/dpr/components/_inputs/granular-date-range/utils.ts
+++ b/src/dpr/components/_inputs/granular-date-range/utils.ts
@@ -72,42 +72,42 @@ const setDateRangeFromQuickFilterValue = (value: string) => {
       break
     case 'last-thirty-days':
       endDate = dayjs()
-      startDate = endDate.subtract(30, 'days')
+      startDate = endDate.subtract(1, 'month').add(1, 'day')
       granularity = 'daily'
       break
     case 'last-month':
       endDate = dayjs()
-      startDate = endDate.subtract(1, 'month')
+      startDate = endDate.subtract(1, 'month').add(1, 'day')
       granularity = 'monthly'
       break
     case 'last-full-month':
       endDate = dayjs().subtract(1, 'month').endOf('month')
-      startDate = endDate.subtract(1, 'month')
+      startDate = endDate.startOf('month')
       granularity = 'monthly'
       break
     case 'last-90-days':
       endDate = dayjs()
-      startDate = endDate.subtract(3, 'month')
+      startDate = endDate.subtract(3, 'month').add(1, 'day')
       granularity = 'daily'
       break
     case 'last-3-months':
       endDate = dayjs()
-      startDate = endDate.subtract(3, 'month')
+      startDate = endDate.subtract(3, 'month').add(1, 'day')
       granularity = 'monthly'
       break
     case 'last-full-3-months':
       endDate = dayjs().subtract(1, 'month').endOf('month')
-      startDate = endDate.subtract(3, 'month')
+      startDate = endDate.subtract(2, 'month').startOf('month')
       granularity = 'monthly'
       break
     case 'last-year':
       endDate = dayjs()
-      startDate = endDate.subtract(1, 'year')
+      startDate = endDate.subtract(1, 'year').add(1, 'day')
       granularity = 'annually'
       break
     case 'last-full-year':
       endDate = dayjs().subtract(1, 'year').endOf('year')
-      startDate = endDate.subtract(1, 'year')
+      startDate = endDate.startOf('year')
       granularity = 'annually'
       break
     case 'tomorrow':
@@ -117,34 +117,47 @@ const setDateRangeFromQuickFilterValue = (value: string) => {
       break
     case 'next-seven-days':
       startDate = dayjs()
-      endDate = dayjs().add(7, 'day')
+      endDate = dayjs().add(7, 'day').subtract(1, 'day')
       granularity = 'daily'
       break
     case 'next-thirty-days':
       startDate = dayjs()
-      endDate = dayjs().add(30, 'day')
+      endDate = dayjs().add(1, 'month').subtract(1, 'day')
       granularity = 'daily'
       break
     case 'next-month':
       startDate = dayjs()
-      endDate = dayjs().add(30, 'day')
+      endDate = dayjs().add(1, 'month').subtract(1, 'day')
+      granularity = 'monthly'
+      break
+    case 'next-full-month':
+      startDate = dayjs().add(1, 'month').startOf('month')
+      endDate = startDate.endOf('month')
       granularity = 'monthly'
       break
     case 'next-90-days':
       startDate = dayjs()
-      endDate = dayjs().add(90, 'day')
+      endDate = dayjs().add(3, 'month').subtract(1, 'day')
       granularity = 'daily'
       break
     case 'next-3-months':
       startDate = dayjs()
-      endDate = dayjs().add(3, 'month')
-      startDate = endDate.subtract(3, 'month')
+      endDate = dayjs().add(3, 'month').subtract(1, 'day')
+      granularity = 'monthly'
+      break
+    case 'next-full-3-months':
+      startDate = dayjs().add(1, 'month').startOf('month')
+      endDate = startDate.add(2, 'month').endOf('month')
       granularity = 'monthly'
       break
     case 'next-year':
       startDate = dayjs()
-      endDate = dayjs().add(1, 'year')
-      startDate = endDate.subtract(1, 'year')
+      endDate = dayjs().add(1, 'year').subtract(1, 'day')
+      granularity = 'annually'
+      break
+    case 'next-full-year':
+      startDate = dayjs().add(1, 'year').startOf('year')
+      endDate = startDate.endOf('year')
       granularity = 'annually'
       break
     default:
@@ -169,10 +182,17 @@ const getOptionDisplayValue = (value: string, options: { text: string; value: st
 const setValueFromRequest = (filter: FilterValue, req: Request, prefix: string) => {
   const { preventDefault } = req.query
 
-  const start = <string>req.query[`${prefix}${filter.name}.start`]
-  const end = <string>req.query[`${prefix}${filter.name}.end`]
-  const granularity = <string>req.query[`${prefix}${filter.name}.granularity`]
   const quickFilter = <string>req.query[`${prefix}${filter.name}.quick-filter`]
+  let granularity
+  let start
+  let end
+  if (quickFilter && quickFilter !== 'none') {
+    ;({ granularity, start, end } = setDateRangeFromQuickFilterValue(quickFilter))
+  } else {
+    granularity = <string>req.query[`${prefix}${filter.name}.granularity`]
+    start = <string>req.query[`${prefix}${filter.name}.start`]
+    end = <string>req.query[`${prefix}${filter.name}.end`]
+  }
 
   const defaultStart = preventDefault ? null : (<GranularDateRange>filter.value)?.start
   const defaultEnd = preventDefault ? null : (<GranularDateRange>filter.value)?.end


### PR DESCRIPTION
- Add future quick filters
- Check + update dates to be consistently inclusive. e.g. a full month is `start: 2025/01/01 end: 2025/01/31`

bug fixes
- updating quick filter query params in url did not update the date picker + granularity values. Defaulted to default start, end and granularity. Fixed 