### PR TITLE
Dpr2 1255 scorecards view metric value

### DIFF
--- a/src/dpr/DprPollingStatusClass.mjs
+++ b/src/dpr/DprPollingStatusClass.mjs
@@ -2,7 +2,7 @@ import { DprClientClass } from './DprClientClass.mjs'
 
 export default class DprPollingStatusClass extends DprClientClass {
   getPollingFrquency() {
-    return '20' // 2 seconds
+    return '2000' // 2 seconds
   }
 
   getPollingStatuses() {

--- a/src/dpr/DprPollingStatusClass.mjs
+++ b/src/dpr/DprPollingStatusClass.mjs
@@ -2,7 +2,7 @@ import { DprClientClass } from './DprClientClass.mjs'
 
 export default class DprPollingStatusClass extends DprClientClass {
   getPollingFrquency() {
-    return '2000' // 2 seconds
+    return '20' // 2 seconds
   }
 
   getPollingStatuses() {

--- a/src/dpr/components/_dashboards/dashboard/view.njk
+++ b/src/dpr/components/_dashboards/dashboard/view.njk
@@ -17,15 +17,13 @@
     <div class="dashboard-content">
       {{ dprReportHeading(data) }}
       {{ dprDashboardFilters(data.filters) }}
-      <br>
-      {{ dprScoreCardGroup(data.scorecards) }}
-      
       {% for metric in data.metrics %}
         <hr class="metric-break">
         <div>
           {{ dprChartCard(metric) }}
         </div>
       {% endfor %}
+      {{ dprScoreCardGroup(data.scorecards) }}
     </div>
   </div>
 {% endmacro %}

--- a/src/dpr/components/_dashboards/dashboard/view.njk
+++ b/src/dpr/components/_dashboards/dashboard/view.njk
@@ -3,6 +3,7 @@
 
 {% from "../../_charts/chart-card/view.njk" import dprChartCard %}
 {% from "../../_reports/report-heading/view.njk" import dprReportHeading %}
+{% from "../scorecard-group/view.njk" import dprScoreCardGroup %}
 
 {%- from "moj/components/side-navigation/macro.njk" import mojSideNavigation -%}
 
@@ -16,6 +17,8 @@
     <div class="dashboard-content">
       {{ dprReportHeading(data) }}
       {{ dprDashboardFilters(data.filters) }}
+      <br>
+      {{ dprScoreCardGroup(data.scorecards) }}
       
       {% for metric in data.metrics %}
         <hr class="metric-break">

--- a/src/dpr/components/_dashboards/scorecard-group/view.njk
+++ b/src/dpr/components/_dashboards/scorecard-group/view.njk
@@ -1,9 +1,18 @@
-{% from "components/scorecard/view.njk" import dprScoreCard %}
+{% from "../scorecard/view.njk" import dprScoreCard %}
 
-{% macro dprScoreCardGroup(scoreCards) %}
+{% macro dprScoreCardGroup(scorecardGroups) %}
+{% for group in scorecardGroups %}
+  {% set title = group.title %}
+  {% set description = group.description %}
+
+  <h2>{{ title }}</h2>
+  <p>{{ description }}</p>
+
   <div class="dpr-scorecard-group">
-    {% for scoreCard in scoreCards %}
-      {{ dprScoreCard(scoreCard) }}
+    {% for scorecard in group.scorecards %}
+      {{ dprScoreCard(scorecard) }}
     {% endfor %}
   </div> 
+
+  {% endfor %}
 {% endmacro %}

--- a/src/dpr/components/_dashboards/scorecard/types.ts
+++ b/src/dpr/components/_dashboards/scorecard/types.ts
@@ -1,0 +1,28 @@
+export interface Scorecard {
+  title: string
+  value: number
+  trend?: ScorecardTrend
+  link?: {
+    href: '#'
+    displayName: 'View breakdown'
+  }
+  valueFor?: string
+  rag?: ScorecardRag
+}
+
+export interface ScorecardGroup {
+  title: string
+  description: string
+  scorecards: Scorecard[]
+}
+
+export interface ScorecardTrend {
+  direction: number
+  value: number
+  from: string
+}
+
+export interface ScorecardRag {
+  score: number
+  color: string
+}

--- a/src/dpr/components/_dashboards/scorecard/utils.test.ts
+++ b/src/dpr/components/_dashboards/scorecard/utils.test.ts
@@ -1,0 +1,114 @@
+import { mockDashboardDataAnalticsScoreCardGroup } from '../../../../../test-app/mocks/mockClients/dashboards/mockDashboardScoreCardDefinitions'
+import { mockTimeSeriesDataLastSixMonths } from '../../../../../test-app/mocks/mockClients/dashboards/mockDashboardResponseData'
+import { MetricsDataResponse } from '../../../types/Metrics'
+import ScorecardUtils from './utils'
+
+describe('Score cards Utils', () => {
+  let rawData: MetricsDataResponse[][]
+
+  beforeEach(() => {
+    rawData = mockTimeSeriesDataLastSixMonths as unknown as MetricsDataResponse[][]
+  })
+
+  describe('createScorecards', () => {
+    it('should create the scorecards', () => {
+      const result = ScorecardUtils.createScorecards(
+        [mockDashboardDataAnalticsScoreCardGroup, mockDashboardDataAnalticsScoreCardGroup],
+        rawData,
+      )
+
+      const expectedScorcardGroup = {
+        title: 'Data Analytics',
+        description: 'Mocked data to display analytics data witin scorecards',
+        scorecards: [
+          {
+            title: 'No. of Prisoners with ethnicity',
+            value: 533,
+            rag: {
+              score: 1,
+              color: 'yellow',
+            },
+            valueFor: 'Jan 25',
+            trend: {
+              direction: 1,
+              value: 109,
+              from: 'Aug 24',
+            },
+          },
+          {
+            title: 'No. of Prisoners with no ethnicity',
+            value: 614,
+            rag: {
+              score: 2,
+              color: 'red',
+            },
+            valueFor: 'Jan 25',
+            trend: {
+              direction: -1,
+              value: 167,
+              from: 'Aug 24',
+            },
+          },
+          {
+            title: 'No. of Prisoners with nationality',
+            value: 684,
+            rag: {
+              score: 2,
+              color: 'red',
+            },
+            valueFor: 'Jan 25',
+            trend: {
+              direction: 1,
+              value: 225,
+              from: 'Aug 24',
+            },
+          },
+          {
+            title: 'No. of Prisoners with no nationality',
+            value: 665,
+            rag: {
+              score: 2,
+              color: 'red',
+            },
+            valueFor: 'Jan 25',
+            trend: {
+              direction: 1,
+              value: 137,
+              from: 'Aug 24',
+            },
+          },
+          {
+            title: 'No. of Prisoners with religion',
+            value: 680,
+            rag: {
+              score: 2,
+              color: 'red',
+            },
+            valueFor: 'Jan 25',
+            trend: {
+              direction: 1,
+              value: 104,
+              from: 'Aug 24',
+            },
+          },
+          {
+            title: 'No. of Prisoners with no religion',
+            value: 799,
+            rag: {
+              score: 2,
+              color: 'red',
+            },
+            valueFor: 'Jan 25',
+            trend: {
+              direction: 1,
+              value: 352,
+              from: 'Aug 24',
+            },
+          },
+        ],
+      }
+
+      expect(result).toEqual([expectedScorcardGroup, expectedScorcardGroup])
+    })
+  })
+})

--- a/src/dpr/components/_dashboards/scorecard/utils.ts
+++ b/src/dpr/components/_dashboards/scorecard/utils.ts
@@ -1,0 +1,66 @@
+import { DashboardScorecard, DashboardScorecardsGroup } from '../../../types/Dashboards'
+import { MetricsDataResponse } from '../../../types/Metrics'
+import { Scorecard, ScorecardGroup, ScorecardTrend } from './types'
+
+const createScoreCard = (scorecardDefinition: DashboardScorecard, rawData: MetricsDataResponse[][]): Scorecard => {
+  // Get last in timeseries data
+  const data = rawData[rawData.length - 1][0]
+  const { column, label: title } = scorecardDefinition
+
+  return {
+    title,
+    value: +data[column].raw,
+    rag: getRag(+data[column].rag),
+    valueFor: data.timestamp as unknown as string,
+    trend: createTrend(rawData, column),
+  }
+}
+
+const createScorecards = (
+  scorecardsDefinition: DashboardScorecardsGroup[],
+  data: MetricsDataResponse[][],
+): ScorecardGroup[] => {
+  const scorecardGroups = scorecardsDefinition.map((group: DashboardScorecardsGroup) => {
+    const { display: title, description, scorecards } = group
+
+    return {
+      title,
+      description,
+      scorecards: scorecards.map((scorecardDefinition: DashboardScorecard) => {
+        return createScoreCard(scorecardDefinition, data)
+      }),
+    }
+  })
+
+  return scorecardGroups
+}
+
+const getRag = (ragScore: number) => {
+  const ragColors = ['green', 'yellow', 'red']
+  return {
+    score: ragScore,
+    color: ragColors[ragScore],
+  }
+}
+
+const createTrend = (rawData: MetricsDataResponse[][], column: string): ScorecardTrend => {
+  const currentData = rawData[rawData.length - 1][0]
+  const startData = rawData[0][0]
+
+  const currentValue = +currentData[column].raw
+  const startValue = +startData[column].raw
+
+  const value = currentValue - startValue
+
+  const direction = Math.sign(value)
+
+  return {
+    direction,
+    value: Math.abs(value),
+    from: startData.timestamp as unknown as string,
+  }
+}
+
+export default {
+  createScorecards,
+}

--- a/src/dpr/components/_dashboards/scorecard/utils.ts
+++ b/src/dpr/components/_dashboards/scorecard/utils.ts
@@ -20,7 +20,7 @@ const createScorecards = (
   scorecardsDefinition: DashboardScorecardsGroup[],
   data: MetricsDataResponse[][],
 ): ScorecardGroup[] => {
-  const scorecardGroups = scorecardsDefinition.map((group: DashboardScorecardsGroup) => {
+  return scorecardsDefinition.map((group: DashboardScorecardsGroup) => {
     const { display: title, description, scorecards } = group
 
     return {
@@ -31,10 +31,6 @@ const createScorecards = (
       }),
     }
   })
-
-  // console.log(JSON.stringify(scorecardGroups, null, 2))
-
-  return scorecardGroups
 }
 
 const getRag = (ragScore: number) => {
@@ -53,12 +49,9 @@ const createTrend = (
   let trendData
   const currentData = rawData[rawData.length - 1][0]
   const startData = rawData[0][0]
-
   const currentValue = +currentData[column].raw
   const startValue = +startData[column].raw
-
   const value = currentValue - startValue
-
   const direction = Math.sign(value)
   const fromData = startData.timestamp as unknown as string
 

--- a/src/dpr/components/_dashboards/scorecard/utils.ts
+++ b/src/dpr/components/_dashboards/scorecard/utils.ts
@@ -6,13 +6,13 @@ const createScoreCard = (scorecardDefinition: DashboardScorecard, rawData: Metri
   // Get last in timeseries data
   const data = rawData[rawData.length - 1][0]
   const { column, label: title } = scorecardDefinition
-
+  const valueFor = data.timestamp as unknown as string
   return {
     title,
     value: +data[column].raw,
     rag: getRag(+data[column].rag),
     valueFor: data.timestamp as unknown as string,
-    trend: createTrend(rawData, column),
+    trend: createTrend(rawData, column, valueFor),
   }
 }
 
@@ -32,6 +32,8 @@ const createScorecards = (
     }
   })
 
+  // console.log(JSON.stringify(scorecardGroups, null, 2))
+
   return scorecardGroups
 }
 
@@ -43,7 +45,12 @@ const getRag = (ragScore: number) => {
   }
 }
 
-const createTrend = (rawData: MetricsDataResponse[][], column: string): ScorecardTrend => {
+const createTrend = (
+  rawData: MetricsDataResponse[][],
+  column: string,
+  valueFor: string,
+): ScorecardTrend | undefined => {
+  let trendData
   const currentData = rawData[rawData.length - 1][0]
   const startData = rawData[0][0]
 
@@ -53,12 +60,17 @@ const createTrend = (rawData: MetricsDataResponse[][], column: string): Scorecar
   const value = currentValue - startValue
 
   const direction = Math.sign(value)
+  const fromData = startData.timestamp as unknown as string
 
-  return {
-    direction,
-    value: Math.abs(value),
-    from: startData.timestamp as unknown as string,
+  if (fromData !== valueFor) {
+    trendData = {
+      direction,
+      value: Math.abs(value),
+      from: startData.timestamp as unknown as string,
+    }
   }
+
+  return trendData
 }
 
 export default {

--- a/src/dpr/components/_dashboards/scorecard/view.njk
+++ b/src/dpr/components/_dashboards/scorecard/view.njk
@@ -5,15 +5,19 @@
   {% set value = args.value %}
   {% set rag = args.rag %}
   {% set link = args.link %}
+  {% set trend = args.trend %}
   {% set valueFor = args.valueFor %}
 
   {% set trend = args.trend %}
-  {% if trend.direction === 'Up' %}
+  {% if trend.direction === 1 %}
     {% set directionIcon = '▲' %}
-  {% elif trend.direction === 'Down' %}
+    {% set directionDisplay = 'Up' %}
+  {% elif trend.direction === -1 %}
     {% set directionIcon = '▼' %}
+    {% set directionDisplay = 'Down' %}
   {% else %}
     {% set directionIcon = '◼' %}
+    {% set directionDisplay = '' %}
   {% endif %}
 
   <div class="dpr-scorecard" data-dpr-module="scorecard">
@@ -21,12 +25,16 @@
       {{ title }}
     </h4>
 
-    <p class="govuk-body dpr-scorecard__value govuk-tag--{{ rag }}">{{ value }}</p>
-    <p class="govuk-body dpr-scorecard__value-description">Status: {{ rag }}</p>
+    <p class="govuk-body dpr-scorecard__value {% if rag %}govuk-tag--{{ rag.color }}{% endif %}">{{ value }}</p>
+    {% if rag %}
+    <p class="govuk-body dpr-scorecard__value-description">Status: {{ rag.score }}</p>
+    {% endif %}
 
+    {% if trend %}
     <p class="govuk-body-s govuk-!-margin-bottom-2">
-      {{ directionIcon }} {{ trend.direction }} {{ trend.value }} from {{ trend.from }}
+      {{ directionIcon }} {{ directionDisplay }} {{ trend.value }} from {{ trend.from }}
     </p>
+    {% endif %}
 
     {% if link.href %}
       <div class="govuk-!-margin-bottom-3">
@@ -34,6 +42,8 @@
       </div>
     {% endif %}
 
-    <p class="dpr-scorecard__value-from govuk-body-s">Value for {{ valueFor }}</p>
+    {% if valueFor %}
+      <p class="dpr-scorecard__value-from govuk-body-s">Value for {{ valueFor }}</p>
+    {% endif %}
   </div>
 {% endmacro %}

--- a/src/dpr/components/_filters/utils.test.ts
+++ b/src/dpr/components/_filters/utils.test.ts
@@ -1,4 +1,5 @@
 import { Request } from 'express'
+import MockDate from 'mockdate'
 import FiltersUtils from './utils'
 import mockVariant from '../../../../test-app/mocks/mockClients/reports/mockVariants/variant1'
 import { components } from '../../types/api'
@@ -145,10 +146,17 @@ describe('Filters Utils tests', () => {
     })
   })
 
-  // TODO:
   describe('setFilterQueryFromFilterDefinition', () => {
     let granularDateRangeSpy
     let dateRangeSpy
+
+    beforeEach(() => {
+      MockDate.set('2024-06-06')
+    })
+
+    afterEach(() => {
+      MockDate.reset()
+    })
 
     it('should set the filter query from the filter definition', () => {
       granularDateRangeSpy = jest.spyOn(GranularDaterangeUtils, 'getQueryFromDefinition')
@@ -223,7 +231,7 @@ describe('Filters Utils tests', () => {
 
       const result = FiltersUtils.setFilterQueryFromFilterDefinition(fields)
       const expectedResult =
-        'filters.field1.start=2003-02-01&filters.field1.end=2006-05-04&filters.field2=2005-02-01&filters.field4.quick-filter=last-six-months&filters.field4.granularity=monthly&filters.field4.start=2024-07-28&filters.field4.end=2025-01-27'
+        'filters.field1.start=2003-02-01&filters.field1.end=2006-05-04&filters.field2=2005-02-01&filters.field4.quick-filter=last-six-months&filters.field4.granularity=monthly&filters.field4.start=2023-12-07&filters.field4.end=2024-06-06'
 
       expect(granularDateRangeSpy).toHaveBeenCalledWith(
         granularDateRangeFilter,

--- a/src/dpr/types/AsyncReportUtils.ts
+++ b/src/dpr/types/AsyncReportUtils.ts
@@ -3,6 +3,7 @@ import { Services } from './Services'
 import { components } from './api'
 import { DashboardMetricDefinition } from './Dashboards'
 import { ReportType } from './UserReports'
+import { ScorecardGroup } from '../components/_dashboards/scorecard/types'
 
 export interface AsyncReportUtilsParams {
   req?: Request
@@ -37,6 +38,7 @@ export interface RequestDataResult {
     csrfToken: string
     template?: string
     metrics?: DashboardMetricDefinition[]
+    scorecards?: ScorecardGroup[]
     type: ReportType
     defaultInteractiveQueryString?: string
   }

--- a/src/dpr/types/Dashboards.ts
+++ b/src/dpr/types/Dashboards.ts
@@ -6,6 +6,7 @@ export interface DashboardDefinition {
   name: string
   description: string
   metrics: DashboardMetricDefinition[]
+  scorecards: DashboardScorecardsGroup[]
   filterFields: components['schemas']['FieldDefinition'][]
 }
 
@@ -18,6 +19,19 @@ export interface DashboardMetricDefinition {
   charts: DashboardChartDefinition[]
 }
 
+export interface DashboardScorecardsGroup {
+  id: string
+  name: string
+  display: string
+  description: string
+  scorecards: DashboardScorecard[]
+}
+
+export interface DashboardScorecard {
+  label: string
+  unit: string
+  column: string
+}
 export interface DashboardChartDefinition {
   type: ChartType
   unit: ChartUnit

--- a/src/dpr/utils/RequestReportUtils.test.ts
+++ b/src/dpr/utils/RequestReportUtils.test.ts
@@ -99,36 +99,36 @@ describe('RequestReportUtils', () => {
   })
 
   describe('renderRequestData', () => {
-    // it('should render the request data for a report', async () => {
-    //   req.params = {
-    //     ...req.params,
-    //     id: 'mockVariantId',
-    //     type: ReportType.REPORT,
-    //   }
+    it('should render the request data for a report', async () => {
+      req.params = {
+        ...req.params,
+        id: 'mockVariantId',
+        type: ReportType.REPORT,
+      }
 
-    //   const result = await RequestReportUtils.renderRequestData({
-    //     req,
-    //     res,
-    //     services,
-    //     next,
-    //   })
+      const result = await RequestReportUtils.renderRequestData({
+        req,
+        res,
+        services,
+        next,
+      })
 
-    //   expect(result).toEqual({
-    //     fields: mockDefinition.variant.specification.fields,
-    //     reportData: {
-    //       reportName: 'reportName',
-    //       name: 'Successful Report',
-    //       description: 'this will succeed',
-    //       reportId: 'reportId',
-    //       id: 'mockVariantId',
-    //       definitionPath: undefined,
-    //       csrfToken: 'csrfToken',
-    //       template: undefined,
-    //       metrics: undefined,
-    //       type: 'report',
-    //     },
-    //   })
-    // })
+      expect(result).toEqual({
+        fields: mockDefinition.variant.specification.fields,
+        reportData: {
+          reportName: 'reportName',
+          name: 'Successful Report',
+          description: 'this will succeed',
+          reportId: 'reportId',
+          id: 'mockVariantId',
+          definitionPath: undefined,
+          csrfToken: 'csrfToken',
+          template: undefined,
+          metrics: undefined,
+          type: 'report',
+        },
+      })
+    })
 
     it('should render the request data for a dashboard', async () => {
       req.params = {

--- a/test-app/mocks/mockClients/dashboards/mockDashboardClient.js
+++ b/test-app/mocks/mockClients/dashboards/mockDashboardClient.js
@@ -83,7 +83,6 @@ const getData = (def, dashboardId, query) => {
     const end = query['filters.date.end']
     const granularity = query['filters.date.granularity']
     const data = mockDahsboardDataHelper.createTimeSeriesData(start, end, granularity, 3)
-    // console.log(JSON.stringify({ data }, null, 2))
     return data
   }
   return mockDahsboardData[dashboardId]

--- a/test-app/mocks/mockClients/dashboards/mockDashboardDefinition.js
+++ b/test-app/mocks/mockClients/dashboards/mockDashboardDefinition.js
@@ -106,7 +106,7 @@ const mockDashboardDefinition10 = {
   id: 'test-dashboard-10',
   name: 'Time series test',
   description: 'Testing a dashboard with timeseries chart & snapshot chart',
-  metrics: [mockDashboardMetricDefMissingEthnicityRaw, mockDashboardMetricDefMissingEthnicityTimeseries],
+  metrics: [mockDashboardMetricDefMissingEthnicityTimeseries, mockDashboardMetricDefMissingEthnicityRaw],
   scorecards: [mockDashboardDataAnalticsScoreCardGroup],
   filterFields: [establishmentIdFilter, granularDateRangeFilter],
 }

--- a/test-app/mocks/mockClients/dashboards/mockDashboardDefinition.js
+++ b/test-app/mocks/mockClients/dashboards/mockDashboardDefinition.js
@@ -7,6 +7,7 @@ const {
 } = require('./mockDashboardMetricDefinitons')
 
 const { establishmentIdFilter, granularDateRangeFilter } = require('./mockDashboardFilterDefinition')
+const { mockDashboardDataAnalticsScoreCardGroup } = require('./mockDashboardScoreCardDefinitions')
 
 const mockDashboardDefinition1 = {
   id: 'test-dashboard-1',
@@ -106,6 +107,7 @@ const mockDashboardDefinition10 = {
   name: 'Time series test',
   description: 'Testing a dashboard with timeseries chart & snapshot chart',
   metrics: [mockDashboardMetricDefMissingEthnicityRaw, mockDashboardMetricDefMissingEthnicityTimeseries],
+  scorecards: [mockDashboardDataAnalticsScoreCardGroup],
   filterFields: [establishmentIdFilter, granularDateRangeFilter],
 }
 

--- a/test-app/mocks/mockClients/dashboards/mockDashboardFilterDefinition.js
+++ b/test-app/mocks/mockClients/dashboards/mockDashboardFilterDefinition.js
@@ -22,6 +22,7 @@ const establishmentIdFilter = {
         display: 'DAI',
       },
     ],
+    defaultValue: 'MDI',
     dynamicOptions: {
       minimumLength: null,
     },

--- a/test-app/mocks/mockClients/dashboards/mockDashboardResponseData.js
+++ b/test-app/mocks/mockClients/dashboards/mockDashboardResponseData.js
@@ -134,6 +134,562 @@ const generateRag = (value) => {
   return ragValue
 }
 
+const mockTimeSeriesDataLastSixMonths = [
+  [
+    {
+      timestamp: 'Aug 24',
+      establishment_id: {
+        raw: 'MDI',
+      },
+      has_ethnicity: {
+        raw: 424,
+        rag: 0,
+      },
+      ethnicity_is_missing: {
+        raw: 781,
+        rag: 2,
+      },
+      has_nationality: {
+        raw: 459,
+        rag: 0,
+      },
+      nationality_is_missing: {
+        raw: 528,
+        rag: 1,
+      },
+      has_religion: {
+        raw: 576,
+        rag: 1,
+      },
+      religion_is_missing: {
+        raw: 447,
+        rag: 0,
+      },
+    },
+    {
+      timestamp: 'Aug 24',
+      establishment_id: {
+        raw: 'SLI',
+      },
+      has_ethnicity: {
+        raw: 761,
+        rag: 2,
+      },
+      ethnicity_is_missing: {
+        raw: 610,
+        rag: 2,
+      },
+      has_nationality: {
+        raw: 734,
+        rag: 2,
+      },
+      nationality_is_missing: {
+        raw: 785,
+        rag: 2,
+      },
+      has_religion: {
+        raw: 758,
+        rag: 2,
+      },
+      religion_is_missing: {
+        raw: 694,
+        rag: 2,
+      },
+    },
+    {
+      timestamp: 'Aug 24',
+      establishment_id: {
+        raw: 'DAI',
+      },
+      has_ethnicity: {
+        raw: 401,
+        rag: 0,
+      },
+      ethnicity_is_missing: {
+        raw: 499,
+        rag: 0,
+      },
+      has_nationality: {
+        raw: 611,
+        rag: 2,
+      },
+      nationality_is_missing: {
+        raw: 524,
+        rag: 1,
+      },
+      has_religion: {
+        raw: 734,
+        rag: 2,
+      },
+      religion_is_missing: {
+        raw: 404,
+        rag: 0,
+      },
+    },
+  ],
+  [
+    {
+      timestamp: 'Sep 24',
+      establishment_id: {
+        raw: 'MDI',
+      },
+      has_ethnicity: {
+        raw: 733,
+        rag: 2,
+      },
+      ethnicity_is_missing: {
+        raw: 514,
+        rag: 1,
+      },
+      has_nationality: {
+        raw: 573,
+        rag: 1,
+      },
+      nationality_is_missing: {
+        raw: 554,
+        rag: 1,
+      },
+      has_religion: {
+        raw: 637,
+        rag: 2,
+      },
+      religion_is_missing: {
+        raw: 430,
+        rag: 0,
+      },
+    },
+    {
+      timestamp: 'Sep 24',
+      establishment_id: {
+        raw: 'SLI',
+      },
+      has_ethnicity: {
+        raw: 559,
+        rag: 1,
+      },
+      ethnicity_is_missing: {
+        raw: 518,
+        rag: 1,
+      },
+      has_nationality: {
+        raw: 453,
+        rag: 0,
+      },
+      nationality_is_missing: {
+        raw: 758,
+        rag: 2,
+      },
+      has_religion: {
+        raw: 562,
+        rag: 1,
+      },
+      religion_is_missing: {
+        raw: 430,
+        rag: 0,
+      },
+    },
+    {
+      timestamp: 'Sep 24',
+      establishment_id: {
+        raw: 'DAI',
+      },
+      has_ethnicity: {
+        raw: 656,
+        rag: 2,
+      },
+      ethnicity_is_missing: {
+        raw: 521,
+        rag: 1,
+      },
+      has_nationality: {
+        raw: 659,
+        rag: 2,
+      },
+      nationality_is_missing: {
+        raw: 531,
+        rag: 1,
+      },
+      has_religion: {
+        raw: 719,
+        rag: 2,
+      },
+      religion_is_missing: {
+        raw: 573,
+        rag: 1,
+      },
+    },
+  ],
+  [
+    {
+      timestamp: 'Oct 24',
+      establishment_id: {
+        raw: 'MDI',
+      },
+      has_ethnicity: {
+        raw: 738,
+        rag: 2,
+      },
+      ethnicity_is_missing: {
+        raw: 598,
+        rag: 1,
+      },
+      has_nationality: {
+        raw: 638,
+        rag: 2,
+      },
+      nationality_is_missing: {
+        raw: 417,
+        rag: 0,
+      },
+      has_religion: {
+        raw: 428,
+        rag: 0,
+      },
+      religion_is_missing: {
+        raw: 767,
+        rag: 2,
+      },
+    },
+    {
+      timestamp: 'Oct 24',
+      establishment_id: {
+        raw: 'SLI',
+      },
+      has_ethnicity: {
+        raw: 692,
+        rag: 2,
+      },
+      ethnicity_is_missing: {
+        raw: 676,
+        rag: 2,
+      },
+      has_nationality: {
+        raw: 758,
+        rag: 2,
+      },
+      nationality_is_missing: {
+        raw: 521,
+        rag: 1,
+      },
+      has_religion: {
+        raw: 430,
+        rag: 0,
+      },
+      religion_is_missing: {
+        raw: 726,
+        rag: 2,
+      },
+    },
+    {
+      timestamp: 'Oct 24',
+      establishment_id: {
+        raw: 'DAI',
+      },
+      has_ethnicity: {
+        raw: 665,
+        rag: 2,
+      },
+      ethnicity_is_missing: {
+        raw: 687,
+        rag: 2,
+      },
+      has_nationality: {
+        raw: 556,
+        rag: 1,
+      },
+      nationality_is_missing: {
+        raw: 615,
+        rag: 2,
+      },
+      has_religion: {
+        raw: 460,
+        rag: 0,
+      },
+      religion_is_missing: {
+        raw: 467,
+        rag: 0,
+      },
+    },
+  ],
+  [
+    {
+      timestamp: 'Nov 24',
+      establishment_id: {
+        raw: 'MDI',
+      },
+      has_ethnicity: {
+        raw: 479,
+        rag: 0,
+      },
+      ethnicity_is_missing: {
+        raw: 522,
+        rag: 1,
+      },
+      has_nationality: {
+        raw: 471,
+        rag: 0,
+      },
+      nationality_is_missing: {
+        raw: 546,
+        rag: 1,
+      },
+      has_religion: {
+        raw: 405,
+        rag: 0,
+      },
+      religion_is_missing: {
+        raw: 431,
+        rag: 0,
+      },
+    },
+    {
+      timestamp: 'Nov 24',
+      establishment_id: {
+        raw: 'SLI',
+      },
+      has_ethnicity: {
+        raw: 635,
+        rag: 2,
+      },
+      ethnicity_is_missing: {
+        raw: 790,
+        rag: 2,
+      },
+      has_nationality: {
+        raw: 581,
+        rag: 1,
+      },
+      nationality_is_missing: {
+        raw: 660,
+        rag: 2,
+      },
+      has_religion: {
+        raw: 780,
+        rag: 2,
+      },
+      religion_is_missing: {
+        raw: 434,
+        rag: 0,
+      },
+    },
+    {
+      timestamp: 'Nov 24',
+      establishment_id: {
+        raw: 'DAI',
+      },
+      has_ethnicity: {
+        raw: 482,
+        rag: 0,
+      },
+      ethnicity_is_missing: {
+        raw: 713,
+        rag: 2,
+      },
+      has_nationality: {
+        raw: 707,
+        rag: 2,
+      },
+      nationality_is_missing: {
+        raw: 751,
+        rag: 2,
+      },
+      has_religion: {
+        raw: 715,
+        rag: 2,
+      },
+      religion_is_missing: {
+        raw: 422,
+        rag: 0,
+      },
+    },
+  ],
+  [
+    {
+      timestamp: 'Dec 24',
+      establishment_id: {
+        raw: 'MDI',
+      },
+      has_ethnicity: {
+        raw: 467,
+        rag: 0,
+      },
+      ethnicity_is_missing: {
+        raw: 431,
+        rag: 0,
+      },
+      has_nationality: {
+        raw: 584,
+        rag: 1,
+      },
+      nationality_is_missing: {
+        raw: 605,
+        rag: 2,
+      },
+      has_religion: {
+        raw: 746,
+        rag: 2,
+      },
+      religion_is_missing: {
+        raw: 423,
+        rag: 0,
+      },
+    },
+    {
+      timestamp: 'Dec 24',
+      establishment_id: {
+        raw: 'SLI',
+      },
+      has_ethnicity: {
+        raw: 577,
+        rag: 1,
+      },
+      ethnicity_is_missing: {
+        raw: 536,
+        rag: 1,
+      },
+      has_nationality: {
+        raw: 524,
+        rag: 1,
+      },
+      nationality_is_missing: {
+        raw: 664,
+        rag: 2,
+      },
+      has_religion: {
+        raw: 721,
+        rag: 2,
+      },
+      religion_is_missing: {
+        raw: 692,
+        rag: 2,
+      },
+    },
+    {
+      timestamp: 'Dec 24',
+      establishment_id: {
+        raw: 'DAI',
+      },
+      has_ethnicity: {
+        raw: 660,
+        rag: 2,
+      },
+      ethnicity_is_missing: {
+        raw: 590,
+        rag: 1,
+      },
+      has_nationality: {
+        raw: 529,
+        rag: 1,
+      },
+      nationality_is_missing: {
+        raw: 708,
+        rag: 2,
+      },
+      has_religion: {
+        raw: 509,
+        rag: 1,
+      },
+      religion_is_missing: {
+        raw: 718,
+        rag: 2,
+      },
+    },
+  ],
+  [
+    {
+      timestamp: 'Jan 25',
+      establishment_id: {
+        raw: 'MDI',
+      },
+      has_ethnicity: {
+        raw: 533,
+        rag: 1,
+      },
+      ethnicity_is_missing: {
+        raw: 614,
+        rag: 2,
+      },
+      has_nationality: {
+        raw: 684,
+        rag: 2,
+      },
+      nationality_is_missing: {
+        raw: 665,
+        rag: 2,
+      },
+      has_religion: {
+        raw: 680,
+        rag: 2,
+      },
+      religion_is_missing: {
+        raw: 799,
+        rag: 2,
+      },
+    },
+    {
+      timestamp: 'Jan 25',
+      establishment_id: {
+        raw: 'SLI',
+      },
+      has_ethnicity: {
+        raw: 484,
+        rag: 0,
+      },
+      ethnicity_is_missing: {
+        raw: 713,
+        rag: 2,
+      },
+      has_nationality: {
+        raw: 700,
+        rag: 2,
+      },
+      nationality_is_missing: {
+        raw: 506,
+        rag: 1,
+      },
+      has_religion: {
+        raw: 771,
+        rag: 2,
+      },
+      religion_is_missing: {
+        raw: 457,
+        rag: 0,
+      },
+    },
+    {
+      timestamp: 'Jan 25',
+      establishment_id: {
+        raw: 'DAI',
+      },
+      has_ethnicity: {
+        raw: 406,
+        rag: 0,
+      },
+      ethnicity_is_missing: {
+        raw: 682,
+        rag: 2,
+      },
+      has_nationality: {
+        raw: 703,
+        rag: 2,
+      },
+      nationality_is_missing: {
+        raw: 409,
+        rag: 0,
+      },
+      has_religion: {
+        raw: 648,
+        rag: 2,
+      },
+      religion_is_missing: {
+        raw: 720,
+        rag: 2,
+      },
+    },
+  ],
+]
+
 module.exports = {
   createTimeSeriesData,
+  mockTimeSeriesDataLastSixMonths,
 }

--- a/test-app/mocks/mockClients/dashboards/mockDashboardResponseData.js
+++ b/test-app/mocks/mockClients/dashboards/mockDashboardResponseData.js
@@ -1,6 +1,6 @@
 const dayjs = require('dayjs')
 
-const establishmentIds = ['MDI', 'KMI', 'DAI']
+const establishmentIds = ['MDI', 'SLI', 'DAI', 'LTI']
 
 const createTimeSeriesData = (start, end, granularity, sets) => {
   const timeseriesArr = createTimestamps(start, end, granularity, sets)
@@ -8,6 +8,10 @@ const createTimeSeriesData = (start, end, granularity, sets) => {
     return item.map((entry) => {
       const hasEthnicity = generateRawValue()
       const ethnicityIsMissing = generateRawValue()
+      const hasNationality = generateRawValue()
+      const nationalityIsMissing = generateRawValue()
+      const hasReligion = generateRawValue()
+      const religionIsMissing = generateRawValue()
 
       return {
         ...entry,
@@ -18,6 +22,22 @@ const createTimeSeriesData = (start, end, granularity, sets) => {
         ethnicity_is_missing: {
           raw: ethnicityIsMissing,
           rag: generateRag(ethnicityIsMissing),
+        },
+        has_nationality: {
+          raw: hasNationality,
+          rag: generateRag(hasNationality),
+        },
+        nationality_is_missing: {
+          raw: nationalityIsMissing,
+          rag: generateRag(nationalityIsMissing),
+        },
+        has_religion: {
+          raw: hasReligion,
+          rag: generateRag(hasReligion),
+        },
+        religion_is_missing: {
+          raw: religionIsMissing,
+          rag: generateRag(religionIsMissing),
         },
       }
     })

--- a/test-app/mocks/mockClients/dashboards/mockDashboardScoreCardDefinitions.js
+++ b/test-app/mocks/mockClients/dashboards/mockDashboardScoreCardDefinitions.js
@@ -1,0 +1,42 @@
+const mockDashboardDataAnalticsScoreCardGroup = {
+  id: 'test-scorecards',
+  name: 'data-analytics',
+  display: 'Data Analytics',
+  description: 'Mocked data to display analytics data witin scorecards',
+  scorecards: [
+    {
+      label: 'No. of Prisoners with ethnicity',
+      unit: 'number',
+      column: 'has_ethnicity',
+    },
+    {
+      label: 'No. of Prisoners with no ethnicity',
+      unit: 'number',
+      column: 'ethnicity_is_missing',
+    },
+    {
+      label: 'No. of Prisoners with nationality',
+      unit: 'number',
+      column: 'has_nationality',
+    },
+    {
+      label: 'No. of Prisoners with no nationality',
+      unit: 'number',
+      column: 'nationality_is_missing',
+    },
+    {
+      label: 'No. of Prisoners with religion',
+      unit: 'number',
+      column: 'has_religion',
+    },
+    {
+      label: 'No. of Prisoners with no religion',
+      unit: 'number',
+      column: 'religion_is_missing',
+    },
+  ],
+}
+
+module.exports = {
+  mockDashboardDataAnalticsScoreCardGroup,
+}


### PR DESCRIPTION
Mocked scorecards in dashboards

Cover these tickets: 
- [View metric value](https://dsdmoj.atlassian.net/browse/DPR2-1255)
- [View RAG coded thresholds](https://dsdmoj.atlassian.net/browse/DPR2-1259)
- [View trend visualisation](https://dsdmoj.atlassian.net/browse/DPR2-1258)

parts:
- FE e2e mocked data from dashboard definition API to render using mocked result data.
- Scorecard group displays a group of scorecards within a dashboard.
- A dashboard can have multiple groups
- Includes:
  - Metric Value
  - Rag status
  - Date of current value
  - Trend data is time period specified 

extras:
- small refactor to dashboard utils to separate large function into smaller ones
- Re-added commented out test