### PR TITLE
fix multiselect when filter def value is undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "docs": "gulp build:docs && eleventy --input=./docs --output=package/dpr --pathprefix hmpps-digital-prison-reporting-frontend",
     "docs:local": "gulp build:docs-local && eleventy --input=./docs --output=package/dpr --pathprefix hmpps-digital-prison-reporting-frontend/package/dpr",
     "test": "npm-run-all --parallel test:*",
-    "test:jest": "jest -t 'setValueFromRequest' --verbose --silent=false",
+    "test:jest": "jest --verbose --silent=false",
     "test:docs": "npm run docs",
     "test:packaging": "npm run package",
     "start-test-app": "npm run package && node $NODE_OPTIONS test-app/start-server.js",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "docs": "gulp build:docs && eleventy --input=./docs --output=package/dpr --pathprefix hmpps-digital-prison-reporting-frontend",
     "docs:local": "gulp build:docs-local && eleventy --input=./docs --output=package/dpr --pathprefix hmpps-digital-prison-reporting-frontend/package/dpr",
     "test": "npm-run-all --parallel test:*",
-    "test:jest": "jest --verbose --silent=false",
+    "test:jest": "jest -t 'setValueFromRequest' --verbose --silent=false",
     "test:docs": "npm run docs",
     "test:packaging": "npm run package",
     "start-test-app": "npm run package && node $NODE_OPTIONS test-app/start-server.js",

--- a/src/dpr/components/_inputs/mulitselect/utils.ts
+++ b/src/dpr/components/_inputs/mulitselect/utils.ts
@@ -7,7 +7,9 @@ const setValueFromRequest = (filter: FilterValue, req: Request, prefix: string) 
   const valueArr = <string[]>req.query[`${prefix}${filter.name}`]
   const valueString = valueArr ? valueArr.join(',') : ''
   const defaultValue = preventDefault ? null : filter.value
-  const defaultValues = preventDefault ? [] : (<string>filter.value).split(',')
+
+  let defaultValues = filter.value ? (<string>filter.value).split(',') : []
+  defaultValues = preventDefault ? [] : defaultValues
 
   return {
     requestfilterValue: valueString || defaultValue,

--- a/src/dpr/components/_inputs/mulitselect/utilt.test.ts
+++ b/src/dpr/components/_inputs/mulitselect/utilt.test.ts
@@ -1,0 +1,79 @@
+import { Request } from 'express'
+import MultiSelectUtils from './utils'
+import { FilterValue } from '../../_filters/types'
+import { FilterType } from '../../_filters/filter-input/enum'
+
+describe('MultiSelectUtils', () => {
+  describe('setValueFromRequest', () => {
+    let filter: FilterValue
+    let req: Request
+    const prefix = 'filters.'
+
+    it('should set the values to a single default value', () => {
+      filter = {
+        text: 'string',
+        name: 'string',
+        value: 'value1',
+        type: FilterType.multiselect,
+      }
+      req = { query: {} } as unknown as Request
+      const result = MultiSelectUtils.setValueFromRequest(filter, req, prefix)
+
+      expect(result).toEqual({
+        requestfilterValue: 'value1',
+        requestfilterValues: ['value1'],
+      })
+    })
+
+    it('should set the values to multiple default values', () => {
+      filter = {
+        text: 'string',
+        name: 'string',
+        value: 'value1,value2',
+        type: FilterType.multiselect,
+      }
+      req = { query: {} } as unknown as Request
+      const result = MultiSelectUtils.setValueFromRequest(filter, req, prefix)
+
+      expect(result).toEqual({
+        requestfilterValue: 'value1,value2',
+        requestfilterValues: ['value1', 'value2'],
+      })
+    })
+
+    it('should init values to an empty array when filter value is empty', () => {
+      filter = {
+        text: 'string',
+        name: 'string',
+        type: FilterType.multiselect,
+      }
+      req = { query: {} } as unknown as Request
+      const result = MultiSelectUtils.setValueFromRequest(filter, req, prefix)
+
+      expect(result).toEqual({
+        requestfilterValue: undefined,
+        requestfilterValues: [],
+      })
+    })
+
+    it('should init values to an empty array when preventDefault is set', () => {
+      filter = {
+        text: 'string',
+        name: 'string',
+        type: FilterType.multiselect,
+        value: 'value1,value2',
+      }
+      req = {
+        query: {
+          preventDefault: true,
+        },
+      } as unknown as Request
+      const result = MultiSelectUtils.setValueFromRequest(filter, req, prefix)
+
+      expect(result).toEqual({
+        requestfilterValue: null,
+        requestfilterValues: [],
+      })
+    })
+  })
+})

--- a/src/dpr/components/report-list/utils.test.ts
+++ b/src/dpr/components/report-list/utils.test.ts
@@ -77,7 +77,7 @@ describe('EmbeddedReportListUtils', () => {
         request,
         response,
         next,
-        getListDataSources: (reportQuery: ReportQuery) => {
+        getListDataSources: () => {
           return {
             data: [],
             count: 0,


### PR DESCRIPTION
When multi-select value is undefined in the definition it breaks due to returning undefined, instead of an empty array.

- Fixed bug
- Added unit testing