### PR TITLE
fix for join when param is a string

### DIFF
--- a/src/dpr/DprQueryParamClass.mjs
+++ b/src/dpr/DprQueryParamClass.mjs
@@ -90,7 +90,10 @@ export default class DprQueryParamClass extends DprClientClass {
     const { name, value, checked, type } = input
     if (checked && !this.queryParams.has(name, value)) {
       let updateType
-      if (type === 'checkbox') updateType = 'append'
+      if (type === 'checkbox') {
+        updateType = 'append'
+        this.updateQueryParam('preventDefault', true)
+      }
       this.updateQueryParam(name, value, updateType)
     } else if (!checked && this.queryParams.has(name, value) && toggle) {
       this.updateQueryParam(name, value, 'delete')

--- a/src/dpr/DprQueryParamClass.mjs
+++ b/src/dpr/DprQueryParamClass.mjs
@@ -36,7 +36,7 @@ export default class DprQueryParamClass extends DprClientClass {
   initInputEvents(elements) {
     Array.from(elements).forEach((input) => {
       input.addEventListener('change', () => {
-        this.setQueryParamFromInput(input, true)
+        this.setQueryParamFromInput(input, true, false)
       })
     })
   }
@@ -49,7 +49,7 @@ export default class DprQueryParamClass extends DprClientClass {
    */
   initQueryParamsFromInputs(elements) {
     Array.from(elements).forEach((input) => {
-      if (input.type !== 'hidden') this.setQueryParamFromInput(input)
+      if (input.type !== 'hidden') this.setQueryParamFromInput(input, false, true)
     })
   }
 
@@ -60,10 +60,10 @@ export default class DprQueryParamClass extends DprClientClass {
    * @param {*} toggleCheckbox
    * @memberof DprQueryParamClass
    */
-  setQueryParamFromInput(input, toggleCheckbox = false) {
+  setQueryParamFromInput(input, toggleCheckbox = false, init = false) {
     const { type } = input
     if (type === 'checkbox' || type === 'radio') {
-      this.setMultiSelectQueryParam(input, toggleCheckbox)
+      this.setMultiSelectQueryParam(input, toggleCheckbox, init)
     } else {
       const { name } = input
       let { value } = input
@@ -85,14 +85,14 @@ export default class DprQueryParamClass extends DprClientClass {
    * @param {*} toggle - adds the delete step on toggle
    * @memberof DprQueryParamClass
    */
-  setMultiSelectQueryParam(input, toggle) {
+  setMultiSelectQueryParam(input, toggle, init) {
     this.queryParams = new URLSearchParams(window.location.search)
     const { name, value, checked, type } = input
     if (checked && !this.queryParams.has(name, value)) {
       let updateType
       if (type === 'checkbox') {
         updateType = 'append'
-        this.updateQueryParam('preventDefault', true)
+        if (!init && name !== 'columns') this.updateQueryParam('preventDefault', true)
       }
       this.updateQueryParam(name, value, updateType)
     } else if (!checked && this.queryParams.has(name, value) && toggle) {

--- a/src/dpr/components/_filters/filters-selected/utils.ts
+++ b/src/dpr/components/_filters/filters-selected/utils.ts
@@ -171,7 +171,7 @@ const disabledDateRange = (f: DateFilterValue, value: (string | DateRange)[], di
 
 const disabledDate = (f: DateFilterValue, value: (string | DateRange)[], displayValue: string) => {
   const { min, max } = <DateFilterValue>f
-  if ((<string>value[0]).includes(min) || (<string>value[1]).includes(max)) {
+  if ((<string>value[0]).includes(min) || (<string>value[0]).includes(max)) {
     let valueType
     if ((<string>value[0]).includes(min)) valueType = 'min'
     if ((<string>value[0]).includes(max)) valueType = 'max'

--- a/src/dpr/components/_inputs/mulitselect/utils.ts
+++ b/src/dpr/components/_inputs/mulitselect/utils.ts
@@ -3,17 +3,21 @@ import { FilterValue } from '../../_filters/types'
 
 const setValueFromRequest = (filter: FilterValue, req: Request, prefix: string) => {
   const { preventDefault } = req.query
+  const queryValue = <string[] | string | undefined>req.query[`${prefix}${filter.name}`]
 
-  const valueArr = <string[]>req.query[`${prefix}${filter.name}`]
-  const valueString = valueArr ? valueArr.join(',') : ''
+  let valueArr: string[]
+  let valueString: string
+  if (queryValue?.length) {
+    valueArr = Array.isArray(queryValue) ? queryValue : [queryValue]
+    valueString = valueArr.join(',')
+  }
   const defaultValue = preventDefault ? null : filter.value
-
   let defaultValues = filter.value ? (<string>filter.value).split(',') : []
   defaultValues = preventDefault ? [] : defaultValues
 
   return {
-    requestfilterValue: valueString || defaultValue,
-    requestfilterValues: valueArr || defaultValues,
+    requestfilterValue: valueString || defaultValue || null,
+    requestfilterValues: valueArr || defaultValues || [],
   }
 }
 

--- a/src/dpr/components/_inputs/mulitselect/utilt.test.ts
+++ b/src/dpr/components/_inputs/mulitselect/utilt.test.ts
@@ -51,7 +51,7 @@ describe('MultiSelectUtils', () => {
       const result = MultiSelectUtils.setValueFromRequest(filter, req, prefix)
 
       expect(result).toEqual({
-        requestfilterValue: undefined,
+        requestfilterValue: null,
         requestfilterValues: [],
       })
     })
@@ -73,6 +73,48 @@ describe('MultiSelectUtils', () => {
       expect(result).toEqual({
         requestfilterValue: null,
         requestfilterValues: [],
+      })
+    })
+
+    it('should init the values from a single query param', () => {
+      filter = {
+        text: 'string',
+        name: 'field1',
+        type: FilterType.multiselect,
+        value: 'value1',
+      }
+      req = {
+        query: {
+          preventDefault: true,
+          'filters.field1': 'value1',
+        },
+      } as unknown as Request
+      const result = MultiSelectUtils.setValueFromRequest(filter, req, prefix)
+
+      expect(result).toEqual({
+        requestfilterValue: 'value1',
+        requestfilterValues: ['value1'],
+      })
+    })
+
+    it('should init the values from multiple query params', () => {
+      filter = {
+        text: 'string',
+        name: 'field1',
+        type: FilterType.multiselect,
+        value: 'value1',
+      }
+      req = {
+        query: {
+          preventDefault: true,
+          'filters.field1': ['value1', 'value2'],
+        },
+      } as unknown as Request
+      const result = MultiSelectUtils.setValueFromRequest(filter, req, prefix)
+
+      expect(result).toEqual({
+        requestfilterValue: 'value1,value2',
+        requestfilterValues: ['value1', 'value2'],
       })
     })
   })

--- a/test-app/mocks/mockClients/reports/mockVariants/variant23-interactive.js
+++ b/test-app/mocks/mockClients/reports/mockVariants/variant23-interactive.js
@@ -136,7 +136,7 @@ const variant23Interactive = {
             { name: 'value8.3', display: 'Value 8.3' },
             { name: 'value8.4', display: 'Value 8.4' },
           ],
-          defaultValue: 'value8.2',
+          defaultValue: 'value8.2,value8.3',
           interactive: true,
         },
       },

--- a/test-app/mocks/mockClients/reports/mockVariants/variant23-interactive.js
+++ b/test-app/mocks/mockClients/reports/mockVariants/variant23-interactive.js
@@ -136,7 +136,7 @@ const variant23Interactive = {
             { name: 'value8.3', display: 'Value 8.3' },
             { name: 'value8.4', display: 'Value 8.4' },
           ],
-          defaultValue: 'value8.2,value8.3',
+          defaultValue: 'value8.2',
           interactive: true,
         },
       },


### PR DESCRIPTION
Multiselect bug fixes:

1. When one checkbox is selected, queryparam comes back as a string.
When multiple are checked, query param is an array.
Therefore `.join(',')` throws error when value is a string 

2. removing all checkboxes from input and applying, resets the input to default - should not do this. So sets `preventDefault` query param when setting checkboxes

3. Date bug.
