### PR TITLE
Dpr2 1836 max daterange bug

### DIFF
--- a/cypress-tests/integration-tests/step-definitions/interactive-journey.ts
+++ b/cypress-tests/integration-tests/step-definitions/interactive-journey.ts
@@ -76,7 +76,7 @@ Then('the filters are reset', () => {
     expect(location.search).not.to.contain(`filters.field1=value1.1`)
     expect(location.search).not.to.contain(`filters.field6=Value+6.1`)
     expect(location.search).to.contain(
-      `filters.field1=value1.2&filters.field3.start=2003-02-01&filters.field3.end=2006-05-04&filters.field7=2003-02-01`,
+      `filters.field1=value1.2&filters.field3.start=2003-02-01&filters.field3.end=2006-05-04&filters.field7=2005-02-01`,
     )
   })
 })

--- a/src/dpr/components/_filters/filters-selected/utils.ts
+++ b/src/dpr/components/_filters/filters-selected/utils.ts
@@ -3,13 +3,17 @@ import { FilterType } from '../filter-input/enum'
 import { FilterValue, DateRange, DateFilterValue, GranularDateRange } from '../types'
 
 const getSelectedFilters = (filters: FilterValue[], prefix: string) => {
+  const emptyValues: string[] = [undefined, null, '']
+
   return filters
     .filter((f) => {
       return (
         (f.value &&
           Object.prototype.hasOwnProperty.call(f.value, 'start') &&
-          (<DateRange>f.value).start !== undefined) ||
-        (f.value && Object.prototype.hasOwnProperty.call(f.value, 'end') && (<DateRange>f.value).end !== undefined) ||
+          !emptyValues.includes((<DateRange>f.value).start)) ||
+        (f.value &&
+          Object.prototype.hasOwnProperty.call(f.value, 'end') &&
+          !emptyValues.includes((<DateRange>f.value).end)) ||
         (f.value &&
           !Object.prototype.hasOwnProperty.call(f.value, 'start') &&
           !Object.prototype.hasOwnProperty.call(f.value, 'end'))
@@ -142,6 +146,7 @@ const getSelectedDate = (f: FilterValue, prefix: string) => {
   const key = [`${prefix}${f.name}`]
   const displayValue = `${f.value}`
   const value = [`"${displayValue}"`]
+
   const { disabled, cantRemoveClass, displayValue: disabledDisplayValue } = disabledDate(f, value, displayValue)
   return {
     key,
@@ -155,7 +160,7 @@ const getSelectedDate = (f: FilterValue, prefix: string) => {
 const disabledDateRange = (f: DateFilterValue, value: (string | DateRange)[], displayValue: string) => {
   const { min, max } = <DateFilterValue>f
 
-  if ((<string>value[0]).includes(min) && (<string>value[1]).includes(max)) {
+  if (min && (<string>value[0]).includes(min) && max && (<string>value[1]).includes(max)) {
     return {
       disabled: true,
       cantRemoveClass: ' interactive-remove-filter-button--disabled',
@@ -171,7 +176,8 @@ const disabledDateRange = (f: DateFilterValue, value: (string | DateRange)[], di
 
 const disabledDate = (f: DateFilterValue, value: (string | DateRange)[], displayValue: string) => {
   const { min, max } = <DateFilterValue>f
-  if ((<string>value[0]).includes(min) || (<string>value[0]).includes(max)) {
+
+  if ((min && (<string>value[0]).includes(min)) || (max && (<string>value[0]).includes(max))) {
     let valueType
     if ((<string>value[0]).includes(min)) valueType = 'min'
     if ((<string>value[0]).includes(max)) valueType = 'max'

--- a/src/dpr/components/_filters/utils.test.ts
+++ b/src/dpr/components/_filters/utils.test.ts
@@ -113,7 +113,7 @@ describe('Filters Utils tests', () => {
             text: 'Field 7',
             name: 'field7',
             type: 'date',
-            value: '2003-02-01',
+            value: '2005-02-01',
             minimumLength: null,
             dynamicResourceEndpoint: null,
             min: '2003-02-01',
@@ -172,14 +172,13 @@ describe('Filters Utils tests', () => {
             },
           },
           {
-            text: 'Field 7: 2003-02-01 (min date)',
+            text: 'Field 7: 2005-02-01',
             key: '["filters.field7"]',
-            value: ['"2003-02-01"'],
-            disabled: true,
-            classes: 'interactive-remove-filter-button interactive-remove-filter-button--disabled',
+            value: ['"2005-02-01"'],
+            disabled: false,
+            classes: 'interactive-remove-filter-button',
             attributes: {
-              'aria-label':
-                'Selected Filter: Field 7: 2003-02-01 (min date). This filter cant be removed. Update the filter input to change the value',
+              'aria-label': 'Selected Filter: Field 7: 2005-02-01. Click to clear this filter',
             },
           },
           {

--- a/src/dpr/components/_filters/utils.ts
+++ b/src/dpr/components/_filters/utils.ts
@@ -1,9 +1,9 @@
-import { Request } from 'express'
+import { Request, Response } from 'express'
 import { FilterType } from './filter-input/enum'
 import type { components } from '../../types/api'
 import type { FilterOption } from './filter-input/types'
 import type { DateRange, FilterValue } from './types'
-import { DEFAULT_FILTERS_PREFIX } from '../../types/ReportQuery'
+import ReportQuery, { DEFAULT_FILTERS_PREFIX } from '../../types/ReportQuery'
 
 import SelectedFiltersUtils from './filters-selected/utils'
 import DateRangeInputUtils from '../_inputs/date-range/utils'
@@ -11,6 +11,7 @@ import DateInputUtils from '../_inputs/date-input/utils'
 import GranularDateRangeInputUtils from '../_inputs/granular-date-range/utils'
 import MultiSelectUtils from '../_inputs/mulitselect/utils'
 import { Granularity, QuickFilters } from '../_inputs/granular-date-range/types'
+import createUrlForParameters from '../../utils/urlHelper'
 
 const setFilterValuesFromRequest = (filters: FilterValue[], req: Request, prefix = 'filters.'): FilterValue[] => {
   const { preventDefault } = req.query
@@ -207,6 +208,54 @@ const getFiltersFromDefinition = (fields: components['schemas']['FieldDefinition
     })
 }
 
+function redirectWithDefaultFilters(
+  reportQuery: ReportQuery,
+  variantDefinition: {
+    id: string
+    name: string
+    resourceName: string
+    description?: string
+    specification?: components['schemas']['Specification']
+  },
+  response: Response,
+  request: Request,
+) {
+  const defaultFilters: Record<string, string> = {}
+  const { fields } = variantDefinition.specification
+
+  if (Object.keys(reportQuery.filters).length === 0) {
+    fields
+      .filter((f) => f.filter && f.filter.defaultValue)
+      .forEach((f) => {
+        if (f.filter.type.toLowerCase() === FilterType.dateRange) {
+          const dates = f.filter.defaultValue.split(' - ')
+
+          if (dates.length >= 1) {
+            // eslint-disable-next-line prefer-destructuring
+            defaultFilters[`${DEFAULT_FILTERS_PREFIX}${f.name}.start`] = dates[0]
+
+            if (dates.length >= 2) {
+              // eslint-disable-next-line prefer-destructuring
+              defaultFilters[`${DEFAULT_FILTERS_PREFIX}${f.name}.end`] = dates[1]
+            }
+          }
+        } else {
+          defaultFilters[`${DEFAULT_FILTERS_PREFIX}${f.name}`] = f.filter.defaultValue
+        }
+      })
+  }
+
+  console.log({ defaultFilters })
+
+  if (Object.keys(defaultFilters).length > 0) {
+    const querystring = createUrlForParameters(reportQuery.toRecordWithFilterPrefix(), defaultFilters, fields)
+    response.redirect(`${request.baseUrl}${request.path}${querystring}`)
+    return true
+  }
+
+  return false
+}
+
 const getFilters = async ({
   fields,
   req,
@@ -233,4 +282,5 @@ export default {
   setFilterValuesFromRequest,
   getFilters,
   setFilterQueryFromFilterDefinition,
+  redirectWithDefaultFilters,
 }

--- a/src/dpr/components/_filters/utils.ts
+++ b/src/dpr/components/_filters/utils.ts
@@ -245,8 +245,6 @@ function redirectWithDefaultFilters(
       })
   }
 
-  console.log({ defaultFilters })
-
   if (Object.keys(defaultFilters).length > 0) {
     const querystring = createUrlForParameters(reportQuery.toRecordWithFilterPrefix(), defaultFilters, fields)
     response.redirect(`${request.baseUrl}${request.path}${querystring}`)

--- a/src/dpr/components/_inputs/date-input/utils.ts
+++ b/src/dpr/components/_inputs/date-input/utils.ts
@@ -15,10 +15,14 @@ const setDateValueWithinMinMax = (filter: components['schemas']['FilterDefinitio
 }
 
 const setValueFromRequest = (filter: FilterValue, req: Request, prefix: string) => {
+  const { preventDefault } = req.query
+  const defaultValue = preventDefault ? null : filter.value
+
   const dateValue = <string>req.query[`${prefix}${filter.name}`]
   const { min } = <DateFilterValue>filter
   const { max } = <DateFilterValue>filter
-  return dateValue || min || max || '1977-05-25'
+
+  return dateValue || defaultValue || min || max || '1977-05-25'
 }
 
 const getFilterFromDefinition = (filter: components['schemas']['FilterDefinition'], filterData: FilterValue) => {

--- a/src/dpr/components/report-list/utils.test.ts
+++ b/src/dpr/components/report-list/utils.test.ts
@@ -7,6 +7,7 @@ import {
   mockRenderDataFromData,
 } from '../../../../test-app/mocks/mockSyncData/mockRenderData'
 import { components } from '../../types/api'
+import FilterUtils from '../_filters/utils'
 
 jest.mock('parseurl', () => ({
   __esModule: true,
@@ -36,10 +37,15 @@ describe('EmbeddedReportListUtils', () => {
       query: {
         dataProductDefinitionsPath: 'dataProductDefinitionsPath',
       },
+      baseUrl: 'baseUrl',
+      path: 'path',
     } as unknown as Request
 
     response = {
       render: jest.fn().mockImplementation(() => {
+        //  do nothing
+      }),
+      redirect: jest.fn().mockImplementation(() => {
         //  do nothing
       }),
     } as unknown as Response
@@ -50,7 +56,28 @@ describe('EmbeddedReportListUtils', () => {
   })
 
   describe('renderListWithDefinition', () => {
+    it('should should redirect with default values', async () => {
+      const args: RenderListWithDefinitionInput = {
+        title: 'Test Report Name',
+        definitionName: 'test-definition-name',
+        variantName: 'Test Variant Name',
+        request,
+        response,
+        next,
+        layoutTemplate: '',
+        token: 'Token',
+        apiUrl: 'apiUrl',
+        apiTimeout: 8000,
+      }
+
+      await ReportListUtils.renderListWithDefinition(args)
+      expect(response.redirect).toHaveBeenCalledWith(
+        'baseUrlpath?selectedPage=1&pageSize=20&sortColumn=field1&sortedAsc=true&columns=field1&columns=field2&columns=field3&columns=field6&dataProductDefinitionsPath=dataProductDefinitionsPath&filters.field1=value1.1&filters.field3=2003-02-01%20-%202006-05-04&filters.field7=value8.2&filters.field7=value8.3',
+      )
+    })
+
     it('should render the list', async () => {
+      jest.spyOn(FilterUtils, 'redirectWithDefaultFilters').mockReturnValue(false)
       const args: RenderListWithDefinitionInput = {
         title: 'Test Report Name',
         definitionName: 'test-definition-name',
@@ -70,6 +97,7 @@ describe('EmbeddedReportListUtils', () => {
     })
 
     it('should render the list with DPD report name', async () => {
+      jest.spyOn(FilterUtils, 'redirectWithDefaultFilters').mockReturnValue(false)
       const args: RenderListWithDefinitionInput = {
         definitionName: 'test-definition-name',
         variantName: 'Test Variant Name',
@@ -91,6 +119,7 @@ describe('EmbeddedReportListUtils', () => {
     })
 
     it('should use the provided definition path', async () => {
+      jest.spyOn(FilterUtils, 'redirectWithDefaultFilters').mockReturnValue(false)
       request = {
         query: {},
       } as unknown as Request
@@ -121,10 +150,11 @@ describe('EmbeddedReportListUtils', () => {
         sortedAsc: true,
       })
 
-      expect(getDefinition).toHaveBeenNthCalledWith(3, 'Token', 'incident-report', 'summary', 'path/from/handler')
+      expect(getDefinition).toHaveBeenNthCalledWith(4, 'Token', 'incident-report', 'summary', 'path/from/handler')
     })
 
     it('should use the provided query definition path', async () => {
+      jest.spyOn(FilterUtils, 'redirectWithDefaultFilters').mockReturnValue(false)
       request = {
         query: {},
       } as unknown as Request
@@ -156,7 +186,7 @@ describe('EmbeddedReportListUtils', () => {
       })
 
       expect(getDefinition).toHaveBeenNthCalledWith(
-        4,
+        5,
         'Token',
         'incident-report',
         'summary',
@@ -167,6 +197,7 @@ describe('EmbeddedReportListUtils', () => {
 
   describe('renderListWithData', () => {
     it('should render the list', async () => {
+      jest.spyOn(FilterUtils, 'redirectWithDefaultFilters').mockReturnValue(false)
       const args: RenderListWithDataInput = {
         title: 'Test variant title',
         reportName: 'Test report name',

--- a/src/dpr/components/report-list/utils.ts
+++ b/src/dpr/components/report-list/utils.ts
@@ -15,6 +15,7 @@ import Dict = NodeJS.Dict
 import ReportActionsUtils from '../_reports/report-actions/utils'
 import { Template } from '../../types/Templates'
 import SyncReportUtils from '../_sync/sync-report/utils'
+import FiltersUtils from '../_filters/utils'
 import { ReportType } from '../../types/UserReports'
 
 function isListWithWarnings(data: Dict<string>[] | ListWithWarnings): data is ListWithWarnings {
@@ -132,23 +133,25 @@ export const renderListWithDefinition = async ({
       definitionsPath: reportDef,
     })
 
-    const getListData: ListDataSources = {
-      data: reportingClient.getListWithWarnings(variantDefinition.resourceName, token, reportQuery),
-      count: reportingClient.getCount(variantDefinition.resourceName, token, reportQuery),
-    }
+    if (!FiltersUtils.redirectWithDefaultFilters(reportQuery, variantDefinition, response, request)) {
+      const getListData: ListDataSources = {
+        data: reportingClient.getListWithWarnings(variantDefinition.resourceName, token, reportQuery),
+        count: reportingClient.getCount(variantDefinition.resourceName, token, reportQuery),
+      }
 
-    await renderList(
-      getListData,
-      variantDefinition,
-      reportQuery,
-      request,
-      response,
-      next,
-      variantName || `${variantDefinition.name}`,
-      layoutTemplate,
-      otherOptions,
-      title || `${reportName}`,
-    )
+      await renderList(
+        getListData,
+        variantDefinition,
+        reportQuery,
+        request,
+        response,
+        next,
+        variantName || `${variantDefinition.name}`,
+        layoutTemplate,
+        otherOptions,
+        title || `${reportName}`,
+      )
+    }
   } catch (error) {
     next(error)
   }

--- a/src/dpr/data/reportingClient.ts
+++ b/src/dpr/data/reportingClient.ts
@@ -32,6 +32,8 @@ export default class ReportingClient {
   getListWithWarnings(resourceName: string, token: string, listRequest: ReportQuery): Promise<ListWithWarnings> {
     logger.info(`Reporting client: Get ${resourceName} list`)
 
+    console.log(JSON.stringify({ listRequest, query: listRequest.toRecordWithFilterPrefix(true) }, null, 2))
+
     return this.restClient
       .getWithHeaders<Array<Dict<string>>>({
         path: `/${resourceName}`,

--- a/src/dpr/data/reportingClient.ts
+++ b/src/dpr/data/reportingClient.ts
@@ -32,8 +32,6 @@ export default class ReportingClient {
   getListWithWarnings(resourceName: string, token: string, listRequest: ReportQuery): Promise<ListWithWarnings> {
     logger.info(`Reporting client: Get ${resourceName} list`)
 
-    console.log(JSON.stringify({ listRequest, query: listRequest.toRecordWithFilterPrefix(true) }, null, 2))
-
     return this.restClient
       .getWithHeaders<Array<Dict<string>>>({
         path: `/${resourceName}`,

--- a/test-app/mocks/mockClients/reports/mockEmbeddedListData.js
+++ b/test-app/mocks/mockClients/reports/mockEmbeddedListData.js
@@ -190,7 +190,7 @@ const mockSyncData = {
           text: 'Field 7',
           name: 'field7',
           type: 'date',
-          value: '2003-02-01',
+          value: '2005-02-01',
           minimumLength: null,
           dynamicResourceEndpoint: null,
           min: '2003-02-01',
@@ -249,14 +249,13 @@ const mockSyncData = {
           },
         },
         {
-          text: 'Field 7: 2003-02-01 (min date)',
+          text: 'Field 7: 2005-02-01',
           key: '["filters.field7"]',
-          value: ['"2003-02-01"'],
-          disabled: true,
-          classes: 'interactive-remove-filter-button interactive-remove-filter-button--disabled',
+          value: ['"2005-02-01"'],
+          disabled: false,
+          classes: 'interactive-remove-filter-button',
           attributes: {
-            'aria-label':
-              'Selected Filter: Field 7: 2003-02-01 (min date). This filter cant be removed. Update the filter input to change the value',
+            'aria-label': 'Selected Filter: Field 7: 2005-02-01. Click to clear this filter',
           },
         },
         {

--- a/test-app/mocks/mockClients/reports/mockSyncListData.js
+++ b/test-app/mocks/mockClients/reports/mockSyncListData.js
@@ -190,7 +190,7 @@ const mockSyncData = {
           text: 'Field 7',
           name: 'field7',
           type: 'date',
-          value: '2003-02-01',
+          value: '2005-02-01',
           minimumLength: null,
           dynamicResourceEndpoint: null,
           min: '2003-02-01',
@@ -249,14 +249,13 @@ const mockSyncData = {
           },
         },
         {
-          text: 'Field 7: 2003-02-01 (min date)',
+          text: 'Field 7: 2005-02-01',
           key: '["filters.field7"]',
-          value: ['"2003-02-01"'],
-          disabled: true,
-          classes: 'interactive-remove-filter-button interactive-remove-filter-button--disabled',
+          value: ['"2005-02-01"'],
+          disabled: false,
+          classes: 'interactive-remove-filter-button',
           attributes: {
-            'aria-label':
-              'Selected Filter: Field 7: 2003-02-01 (min date). This filter cant be removed. Update the filter input to change the value',
+            'aria-label': 'Selected Filter: Field 7: 2005-02-01. Click to clear this filter',
           },
         },
         {


### PR DESCRIPTION
Embedded reports bug fixes:

- Max date range was being set n selected filters when min max values were null
- Date input was defaulting to min value on reset
- Report was not initially loading with correct query params