### PR TITLE
DPR2-1843 change cancel execution endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Below you can find the changes included in each release.
 
+## v4.1.10
+
+- Change to call a difference execution cancellation endpoint for dashboards to support dashboards running on other data sources apart from Redshift.
+
 ## v4.1.9
 
 - Dashbaord request filters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,9 @@
 Below you can find the changes included in each release.
 
-## v4.1.10
-
-- Change to call a difference execution cancellation endpoint for dashboards to support dashboards running on other data sources apart from Redshift.
-
 ## v4.1.9
 
 - Dashbaord request filters
+- Change to call a difference execution cancellation endpoint for dashboards to support dashboards running on other data sources apart from Redshift.
 
 ## v4.1.8
 

--- a/src/dpr/data/dashboardClient.test.ts
+++ b/src/dpr/data/dashboardClient.test.ts
@@ -94,7 +94,7 @@ describe('dashboardClient', () => {
 
   describe('cancelAsyncRequest', () => {
     it('should request an async dashboard', async () => {
-      fakeDashboardApi.delete(`/statements/exId`).reply(200, {
+      fakeDashboardApi.delete(`/reports/dpd-id/dashboards/test-dashboard-id/statements/exId`).reply(200, {
         cancellationSucceeded: 'true',
       })
 

--- a/src/dpr/data/dashboardClient.ts
+++ b/src/dpr/data/dashboardClient.ts
@@ -90,7 +90,7 @@ export default class DashboardClient {
 
     return this.restClient
       .delete({
-        path: `/statements/${executionId}`,
+        path: `/reports/${reportId}/dashboards/${dashboardId}/statements/${executionId}`,
         token,
       })
       .then((response) => <Dict<string>>response)


### PR DESCRIPTION
Change to call a difference execution cancellation endpoint for dashboards to support dashboards running on other data sources apart from Redshift