### PR TITLE
update establishment autocomplete with user context data

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "docs:serve": "serve dist-docs/dpr",
     "docs:local": "concurrently -k -p \"[{name}]\" -n \"ESBuild,Node\" -c \"yellow.bold,cyan.bold\" \"node esbuild/esbuild.docs.config.js --build --watch --local\" \"node esbuild/esbuild.docs.config.js --local --dev-server\"",
     "test": "npm-run-all --parallel test:*",
-    "test:jest": "jest --verbose --silent=false",
+    "test:jest": "jest -t 'setUserContextDefaults' --verbose --silent=false",
     "test:docs": "npm run docs",
     "test:packaging": "npm run package",
     "start-test-app": "npm run package && node $NODE_OPTIONS test-app/start-server.js",

--- a/src/dpr/components/_filters/utils.test.ts
+++ b/src/dpr/components/_filters/utils.test.ts
@@ -1,4 +1,4 @@
-import { Request } from 'express'
+import { Request, Response } from 'express'
 import MockDate from 'mockdate'
 import FiltersUtils from './utils'
 import mockVariant from '../../../../test-app/mocks/mockClients/reports/mockVariants/variant1'
@@ -1282,6 +1282,167 @@ describe('Filters Utils tests', () => {
       ]
 
       expect(res).toEqual(expectedRes)
+    })
+  })
+
+  describe('setUserContextDefaults', () => {
+    it('should set the filter values from the user context', () => {
+      const res = {
+        locals: {
+          user: {
+            activeCaseLoadId: 'Inigo Montoya',
+          },
+        },
+      } as unknown as Response
+
+      const filterValues: FilterValue[] = [
+        {
+          text: 'Field 1',
+          name: 'field1',
+          type: FilterType.radio,
+          value: 'value1.1',
+          minimumLength: null,
+          dynamicResourceEndpoint: null,
+          mandatory: false,
+          options: [
+            {
+              value: 'value1.1',
+              text: 'Value 1.1',
+            },
+            {
+              value: 'value1.2',
+              text: 'Value 1.2',
+            },
+          ],
+        },
+        {
+          text: 'Field 2',
+          name: 'field2 Establishment',
+          type: FilterType.autocomplete,
+          value: null,
+          minimumLength: 3,
+          dynamicResourceEndpoint: null,
+          mandatory: false,
+          options: [
+            {
+              value: 'Fezzick',
+              text: 'Fezzick',
+            },
+            {
+              value: 'Inigo Montoya',
+              text: 'Inigo Montoya',
+            },
+            {
+              value: 'PrHu',
+              text: 'Prince Humperdink',
+            },
+            {
+              value: 'Princess Buttercup',
+              text: 'Princess Buttercup',
+            },
+            {
+              value: 'Westley',
+              text: 'Westley',
+            },
+          ],
+        },
+        {
+          text: 'Field 3',
+          name: 'field3',
+          type: FilterType.text,
+          value: null,
+          minimumLength: null,
+          dynamicResourceEndpoint: null,
+          mandatory: false,
+        },
+      ]
+
+      const result = FiltersUtils.setUserContextDefaults(res, filterValues)
+
+      expect(result).toEqual([
+        filterValues[0],
+        {
+          ...filterValues[1],
+          value: 'Inigo Montoya',
+        },
+        filterValues[2],
+      ])
+    })
+
+    it('should not set the filter values from the user context', () => {
+      const res = {
+        locals: {
+          user: {
+            activeCaseLoadId: 'Inigo Montoya',
+          },
+        },
+      } as unknown as Response
+
+      const filterValues: FilterValue[] = [
+        {
+          text: 'Field 1',
+          name: 'field1',
+          type: FilterType.radio,
+          value: 'value1.1',
+          minimumLength: null,
+          dynamicResourceEndpoint: null,
+          mandatory: false,
+          options: [
+            {
+              value: 'value1.1',
+              text: 'Value 1.1',
+            },
+            {
+              value: 'value1.2',
+              text: 'Value 1.2',
+            },
+          ],
+        },
+        {
+          text: 'Field 2',
+          name: 'field2',
+          type: FilterType.autocomplete,
+          value: null,
+          minimumLength: 3,
+          dynamicResourceEndpoint: null,
+          mandatory: false,
+          options: [
+            {
+              value: 'Fezzick',
+              text: 'Fezzick',
+            },
+            {
+              value: 'Inigo Montoya',
+              text: 'Inigo Montoya',
+            },
+            {
+              value: 'PrHu',
+              text: 'Prince Humperdink',
+            },
+            {
+              value: 'Princess Buttercup',
+              text: 'Princess Buttercup',
+            },
+            {
+              value: 'Westley',
+              text: 'Westley',
+            },
+          ],
+        },
+        {
+          text: 'Field 3',
+          name: 'field3',
+          type: FilterType.text,
+          value: null,
+          minimumLength: null,
+          dynamicResourceEndpoint: null,
+          mandatory: false,
+        },
+      ]
+
+      const result = FiltersUtils.setUserContextDefaults(res, filterValues)
+
+      expect(result).toEqual([filterValues[0], filterValues[1], filterValues[2]])
     })
   })
 })

--- a/src/dpr/components/_filters/utils.ts
+++ b/src/dpr/components/_filters/utils.ts
@@ -212,6 +212,22 @@ const setUserDefinedDefaultValuesForReport = async (
   return defaultValuesConfig
 }
 
+const setUserContextDefaults = (res: Response, filters: FilterValue[]) => {
+  const { activeCaseLoadId } = localsHelper.getValues(res)
+
+  filters.forEach((filter) => {
+    if (
+      filter.type.toLocaleLowerCase() === FilterType.autocomplete.toLocaleLowerCase() &&
+      filter.name.toLocaleLowerCase().includes('establishment') &&
+      activeCaseLoadId.length
+    ) {
+      filter.value = activeCaseLoadId
+    }
+  })
+
+  return filters
+}
+
 const getFiltersFromDefinition = (fields: components['schemas']['FieldDefinition'][], interactive?: boolean) => {
   return fields
     .filter((f) => f.filter)
@@ -400,4 +416,5 @@ export default {
   redirectWithDefaultFilters,
   setFilterValuesFromSavedDefaults,
   setUserDefinedDefaultValuesForReport,
+  setUserContextDefaults,
 }

--- a/src/dpr/components/_inputs/autocomplete-text-input/clientClass.mjs
+++ b/src/dpr/components/_inputs/autocomplete-text-input/clientClass.mjs
@@ -20,6 +20,13 @@ export default class Autocomplete extends DprClientClass {
       this.onTextInput(event, textInput)
     })
 
+    textInput.addEventListener('keypress', (e) => {
+      if (e.key === 'Enter') {
+        e.stopPropagation()
+        e.preventDefault()
+      }
+    })
+
     this.getElement()
       .querySelectorAll('.autocomplete-text-input-list-button')
       .forEach((button) => {
@@ -51,8 +58,10 @@ export default class Autocomplete extends DprClientClass {
       this.getElement()
         .querySelectorAll(this.listItemsSelector)
         .forEach((item) => {
-          if (searchValue.length >= minLength &&
-            this.isMatchingStaticOptionNameOrDisplayPrefix(this.getInputListButton(item), searchValue, item)) {
+          if (
+            searchValue.length >= minLength &&
+            this.isMatchingStaticOptionNameOrDisplayPrefix(this.getInputListButton(item), searchValue, item)
+          ) {
             item.classList.remove('autocomplete-text-input-item-hide')
           } else {
             item.classList.add('autocomplete-text-input-item-hide')
@@ -71,8 +80,10 @@ export default class Autocomplete extends DprClientClass {
   }
 
   isMatchingStaticOptionNameOrDisplayPrefix(inputListButton, searchValue, item) {
-    return this.isStaticOptionsNamePrefix(inputListButton.dataset.staticOptionNameValue, searchValue)
-      || item.innerText.trim().toLowerCase().startsWith(searchValue)
+    return (
+      this.isStaticOptionsNamePrefix(inputListButton.dataset.staticOptionNameValue, searchValue) ||
+      item.innerText.trim().toLowerCase().startsWith(searchValue)
+    )
   }
 
   isStaticOptionsNamePrefix(staticOptionNameValue, searchValue) {

--- a/src/dpr/utils/localsHelper.ts
+++ b/src/dpr/utils/localsHelper.ts
@@ -6,6 +6,7 @@ const getValues = (res: Response) => {
   const csrfToken = (res.locals.csrfToken as unknown as string) || 'csrfToken'
   const userId = res.locals.user?.uuid ? res.locals.user.uuid : 'userId'
   const token = res.locals.user?.token ? res.locals.user.token : 'token'
+  const activeCaseLoadId = res.locals.user?.activeCaseLoadId || ''
   const pathSuffix = res.locals.pathSuffix || ''
   const routePrefix = res.locals.routePrefix || ''
   const definitions = res.locals.definitions || []
@@ -29,6 +30,7 @@ const getValues = (res: Response) => {
     definitionsPath,
     pathSuffix,
     routePrefix,
+    activeCaseLoadId,
   }
 }
 

--- a/test-app/app.js
+++ b/test-app/app.js
@@ -2,9 +2,10 @@
 /* eslint-disable new-cap */
 // Core dependencies
 
-const fs = require('fs')
 import path from 'path'
 import noCache from 'nocache'
+
+const fs = require('fs')
 // NPM dependencies
 const express = require('express')
 const nunjucks = require('nunjucks')
@@ -27,15 +28,14 @@ app.use(bodyParser.urlencoded({ extended: false }))
 
 let assetManifest = {}
 
-  try {
-    const assetMetadataPath = path.resolve(__dirname, 'assets/manifest.json')
-    assetManifest = JSON.parse(fs.readFileSync(assetMetadataPath, 'utf8'))
-  } catch (e) {
-    if (process.env.NODE_ENV !== 'test') {
-      console.error(`Could not read asset manifest file: ${e} -- ${__dirname}`)
-    }
+try {
+  const assetMetadataPath = path.resolve(__dirname, 'assets/manifest.json')
+  assetManifest = JSON.parse(fs.readFileSync(assetMetadataPath, 'utf8'))
+} catch (e) {
+  if (process.env.NODE_ENV !== 'test') {
+    console.error(`Could not read asset manifest file: ${e} -- ${__dirname}`)
   }
-
+}
 
 // Nunjucks configurations
 const nunjucksEnvironment = nunjucks.configure(appViews, {
@@ -68,7 +68,7 @@ function setUpStaticResources() {
     '/node_modules/@ministryofjustice/frontend',
     '/node_modules/@microsoft/applicationinsights-web/dist/es5',
     '/node_modules/@microsoft/applicationinsights-clickanalytics-js/dist/es5',
-  ).forEach(dir => {
+  ).forEach((dir) => {
     router.use('/assets', express.static(path.join(process.cwd(), dir), cacheControl))
   })
 
@@ -87,7 +87,7 @@ app.use(bodyParser.json())
 // Mock middleware
 const addMockUserData = (req, res, next) => {
   const uuid = 'userId'
-  const activeCaseLoadId = 'random-caseload-id-1'
+  const activeCaseLoadId = 'KMI'
 
   res.locals.user = {
     displayName: 'Test User',

--- a/test-app/mocks/mockClients/reports/mockVariants/variant1.js
+++ b/test-app/mocks/mockClients/reports/mockVariants/variant1.js
@@ -67,6 +67,7 @@ const variant1 = {
         type: 'string',
         filter: {
           type: 'autocomplete',
+          defaultValue: 'Fezzick',
           dynamicOptions: {
             minimumLength: 3,
             returnAsStaticOptions: true,


### PR DESCRIPTION
- Uses activeCaseloadId from the user context
- Checks for an input type of `autocomplete` that has `establishment` in the name

this is not as robust as it could be with some BE work to provide a unique key to identify the correct field to update with the user context. However the current method of targeting the correct input will work as a composite key as by convention the word `establishment` will appear in the name of this field. 