### PR TITLE
Fix for display name in establishments autocomplete + dprContext for locals

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "docs:serve": "serve dist-docs/dpr",
     "docs:local": "concurrently -k -p \"[{name}]\" -n \"ESBuild,Node\" -c \"yellow.bold,cyan.bold\" \"node esbuild/esbuild.docs.config.js --build --watch --local\" \"node esbuild/esbuild.docs.config.js --local --dev-server\"",
     "test": "npm-run-all --parallel test:*",
-    "test:jest": "jest --verbose --silent=false",
+    "test:jest": "jest -t 'LocalsHelper' --verbose --silent=false",
     "test:docs": "npm run docs",
     "test:packaging": "npm run package",
     "start-test-app": "npm run package && node $NODE_OPTIONS test-app/start-server.js",

--- a/src/dpr/components/_filters/filter-input/view.njk
+++ b/src/dpr/components/_filters/filter-input/view.njk
@@ -15,6 +15,7 @@
   {% set name = parameterPrefix + filter.name %}
   {% set value = filter.value %}
   {% set values = filter.values %}
+  {% set values = filter.values %}
   {% set text = filter.text %}
   {% set options = filter.options %}
   {% set pattern = filter.pattern if filter.pattern else 
@@ -108,6 +109,7 @@
         name: name,
         items: options,
         value: value,
+        staticOptionNameValue: filter.staticOptionNameValue,
         labelText: labelText,
         minimumLength: minimumLength,
         dynamicResourceEndpoint: dynamicResourceEndpoint,

--- a/src/dpr/components/_filters/types.d.ts
+++ b/src/dpr/components/_filters/types.d.ts
@@ -18,6 +18,7 @@ export interface GenericFilterValue {
   type: FilterType
   value?: string
   values?: string[]
+  staticOptionNameValue?: string
   options?: Array<FilterOption>
   minimumLength?: number
   dynamicResourceEndpoint?: string

--- a/src/dpr/components/_filters/utils.ts
+++ b/src/dpr/components/_filters/utils.ts
@@ -221,7 +221,12 @@ const setUserContextDefaults = (res: Response, filters: FilterValue[]) => {
       filter.text.toLocaleLowerCase().includes('establishment') &&
       activeCaseLoadId.length
     ) {
-      filter.value = activeCaseLoadId
+      const option = filter.options.find((opt) => opt.value === activeCaseLoadId)
+
+      if (option) {
+        filter.value = option.text
+        filter.staticOptionNameValue = activeCaseLoadId
+      }
     }
   })
 

--- a/src/dpr/components/_inputs/autocomplete-text-input/clientClass.mjs
+++ b/src/dpr/components/_inputs/autocomplete-text-input/clientClass.mjs
@@ -34,6 +34,12 @@ export default class Autocomplete extends DprClientClass {
           this.onOptionClick(event, textInput, this.getElement())
         })
       })
+
+    this.initialiseDefaultValue(textInput)
+  }
+
+  initialiseDefaultValue(textInput) {
+    this.setValue(textInput, textInput.value, textInput.dataset.staticOptionNameValue)
   }
 
   getTextInput() {
@@ -111,16 +117,21 @@ export default class Autocomplete extends DprClientClass {
 
   onOptionClick(event, textInput, topLevelElement) {
     event.preventDefault()
-    // eslint-disable-next-line no-param-reassign
-    textInput.value = event.target.innerText.trim()
-    textInput.staticOptionNameValue = event.target.dataset.staticOptionNameValue
-    textInput.focus()
-    const changeEvent = new Event('change')
-    textInput.dispatchEvent(changeEvent)
-
+    this.setValue(textInput, event.target.innerText.trim(), event.target.dataset.staticOptionNameValue)
     topLevelElement.querySelectorAll('li').forEach((item) => {
       item.classList.add('autocomplete-text-input-item-hide')
     })
+  }
+
+  setValue(textInput, value, staticOptionNameValue) {
+    // eslint-disable-next-line no-param-reassign
+    textInput.value = value
+    // eslint-disable-next-line no-param-reassign
+    textInput.staticOptionNameValue = staticOptionNameValue
+
+    textInput.focus()
+    const changeEvent = new Event('change')
+    textInput.dispatchEvent(changeEvent)
   }
 
   addItem(template, content, clickEvent) {

--- a/src/dpr/components/_inputs/autocomplete-text-input/view.njk
+++ b/src/dpr/components/_inputs/autocomplete-text-input/view.njk
@@ -4,6 +4,8 @@
 {% macro dprAutocompleteTextInput(options) %}
 
     {%  set listId = (options.id | replace(".", "")) + "-list" %}
+    {{ options | json }}
+
     <div class="dpr-autocomplete-text-input" data-dpr-module="autocomplete-text-input">
         {{ govukInput({
             id: options.id,
@@ -27,8 +29,9 @@
                 "placeholder": "Search",
                 "role": "combobox",
                 pattern: options.pattern,
-                required: true,
-                'display-name': options.labelText
+                'display-name': options.labelText,
+                "data-static-option-name-value": options.staticOptionNameValue,
+                required: true
             } if options.mandatory else {
                 "aria-autocomplete": "list",
                 "aria-expanded": "false",
@@ -39,7 +42,8 @@
                 "placeholder": "Search",
                 "role": "combobox",
                 pattern: options.pattern,
-                'display-name': options.labelText
+                'display-name': options.labelText,
+                "data-static-option-name-value": options.staticOptionNameValue
             },
             autocomplete: "off",
             suffix: {

--- a/src/dpr/middleware/setUpDprResources.test.ts
+++ b/src/dpr/middleware/setUpDprResources.test.ts
@@ -142,38 +142,4 @@ describe('setUpDprResources', () => {
       expect(services.reportingService.getDefinitions).toHaveBeenCalledWith('T0k3n', 'dpd/path/from/query')
     })
   })
-
-  describe('setRoutePrefix', () => {
-    let res: Response
-
-    beforeEach(() => {
-      res = {
-        locals: {},
-      } as unknown as Response
-    })
-
-    it('should set the route suffix to blank', async () => {
-      await Middleware.setRoutePrefix(res, { routePrefix: 'dpr' })
-
-      expect(res.locals.routePrefix).toEqual('')
-    })
-
-    it('should set the route suffix to /dpr', async () => {
-      await Middleware.setRoutePrefix(res, {})
-
-      expect(res.locals.routePrefix).toEqual('/dpr')
-    })
-
-    it('should set the route suffix to /dpr when no config provided', async () => {
-      await Middleware.setRoutePrefix(res)
-
-      expect(res.locals.routePrefix).toEqual('/dpr')
-    })
-
-    it('should set the route suffix to /my-path-prefix when config provided', async () => {
-      await Middleware.setRoutePrefix(res, { routePrefix: '/my-path-prefix' })
-
-      expect(res.locals.routePrefix).toEqual('/my-path-prefix')
-    })
-  })
 })

--- a/src/dpr/middleware/setUpDprResources.ts
+++ b/src/dpr/middleware/setUpDprResources.ts
@@ -25,16 +25,11 @@ export default (services: Services, config?: DprConfig): RequestHandler => {
     try {
       await populateDefinitions(services, req, res, config)
       await populateRequestedReports(services, res)
-      setRoutePrefix(res, config)
       return next()
     } catch (error) {
       return next(error)
     }
   }
-}
-
-export const setRoutePrefix = async (res: Response, config?: DprConfig) => {
-  res.locals.routePrefix = getRoutePrefix(config)
 }
 
 export const populateDefinitions = async (services: Services, req: Request, res: Response, config?: DprConfig) => {

--- a/src/dpr/utils/localsHelper.test.ts
+++ b/src/dpr/utils/localsHelper.test.ts
@@ -1,8 +1,5 @@
 import { Response, Request } from 'express'
 import LocalsHelper from './localsHelper'
-import { StoredReportData } from '../types/UserReports'
-import { BookmarkStoreData } from '../types/Bookmark'
-import { components } from '../types/api'
 
 describe('LocalsHelper', () => {
   let res: Response
@@ -28,22 +25,44 @@ describe('LocalsHelper', () => {
   })
 
   describe('getValues', () => {
-    it('should get the local values', () => {
+    it('should set the user context from the user', () => {
+      res.locals.user = {
+        uuid: 'userIdValueOne',
+        token: 'userToken',
+        activeCaseLoadId: 'KMI',
+      }
       const values = LocalsHelper.getValues(res)
 
-      const expected = {
-        activeCaseLoadId: '',
-        csrfToken: 'csrfTokenValue',
-        userId: 'userIdValue',
-        token: 'token',
-        pathSuffix: '',
-        routePrefix: '',
-        recentlyViewedReports: [] as StoredReportData[],
-        requestedReports: [] as StoredReportData[],
-        bookmarks: [] as BookmarkStoreData[],
-        definitions: [] as components['schemas']['ReportDefinitionSummary'][],
+      expect(values).toEqual(
+        expect.objectContaining({
+          userId: 'userIdValueOne',
+          token: 'userToken',
+          activeCaseLoadId: 'KMI',
+        }),
+      )
+    })
+
+    it('should set the user context from the dpr context', () => {
+      res.locals.user = {
+        uuid: 'userIdValue',
+        token: 'userToken',
+        activeCaseLoadId: 'KMI',
       }
-      expect(values).toEqual(expected)
+      res.locals.dprContext = {
+        uuid: 'dprContextIdValue',
+        token: 'dprContextToken',
+        activeCaseLoadId: 'MDI',
+      }
+
+      const values = LocalsHelper.getValues(res)
+
+      expect(values).toEqual(
+        expect.objectContaining({
+          userId: 'dprContextIdValue',
+          token: 'dprContextToken',
+          activeCaseLoadId: 'MDI',
+        }),
+      )
     })
   })
 

--- a/src/dpr/utils/localsHelper.ts
+++ b/src/dpr/utils/localsHelper.ts
@@ -1,44 +1,69 @@
 import type { Response, Request } from 'express'
 import { StoredReportData } from '../types/UserReports'
 import { BookmarkStoreData } from '../types/Bookmark'
+import { components } from '../types/api'
 
 const getValues = (res: Response) => {
   const csrfToken = (res.locals.csrfToken as unknown as string) || 'csrfToken'
-  const userId = res.locals.user?.uuid ? res.locals.user.uuid : 'userId'
-  const token = res.locals.user?.token ? res.locals.user.token : 'token'
-  const activeCaseLoadId = res.locals.user?.activeCaseLoadId || ''
-  const pathSuffix = res.locals.pathSuffix || ''
-  const routePrefix = res.locals.routePrefix || ''
-  const definitions = res.locals.definitions || []
+
+  return {
+    ...setUserContext(res),
+    ...setUserReports(res),
+    ...setDpdPaths(res),
+    ...setFeatures(res),
+    ...setDefinitions(res),
+    csrfToken,
+    nestedBaseUrl: res.locals.nestedBaseUrl,
+  }
+}
+
+const setDefinitions = (res: Response) => {
+  const definitions: Array<components['schemas']['ReportDefinitionSummary']> = res.locals.definitions || []
+  return {
+    definitions,
+  }
+}
+
+const setFeatures = (res: Response) => {
+  return {
+    bookmarkingEnabled: <boolean>res.locals.bookmarkingEnabled || false,
+    downloadingEnabled: <boolean>res.locals.downloadingEnabled || false,
+  }
+}
+
+const setUserReports = (res: Response) => {
   const requestedReports: StoredReportData[] = res.locals.requestedReports || []
   const recentlyViewedReports: StoredReportData[] = res.locals.recentlyViewedReports || []
   const bookmarks: BookmarkStoreData[] = res.locals.bookmarks || []
-  const {
-    bookmarkingEnabled,
-    downloadingEnabled,
-    definitionsPath,
-    dpdPathFromQuery,
-    dpdPathFromConfig,
-    nestedBaseUrl,
-  } = res.locals
 
   return {
-    csrfToken,
-    userId,
-    token,
-    definitions,
     requestedReports,
     recentlyViewedReports,
     bookmarks,
-    bookmarkingEnabled,
-    downloadingEnabled,
+  }
+}
+
+const setDpdPaths = (res: Response) => {
+  const { definitionsPath, dpdPathFromQuery, dpdPathFromConfig, pathSuffix } = res.locals
+  return {
+    definitionsPath,
     dpdPathFromQuery,
     dpdPathFromConfig,
-    definitionsPath,
-    pathSuffix,
-    routePrefix,
+    pathSuffix: pathSuffix || '',
+  }
+}
+
+const setUserContext = (res: Response) => {
+  const { dprContext, user } = res.locals
+
+  const userId = dprContext?.uuid || user?.uuid
+  const token = dprContext?.token || user?.token
+  const activeCaseLoadId = dprContext?.activeCaseLoadId || user.activeCaseLoadId
+
+  return {
+    userId,
+    token,
     activeCaseLoadId,
-    nestedBaseUrl,
   }
 }
 

--- a/test-app/middleware/setUpMockUser.ts
+++ b/test-app/middleware/setUpMockUser.ts
@@ -5,14 +5,19 @@ export default (): RequestHandler => {
     try {
       const uuid = 'userId'
       const activeCaseLoadId = 'KMI'
+      const token = 'mockToken'
 
       res.locals.user = {
         displayName: 'Test User',
         email: 'test@user.com',
+      }
+
+      res.locals.dprContext = {
         uuid,
         activeCaseLoadId,
-        token: 'token',
+        token,
       }
+
       return next()
     } catch (error) {
       return next(error)

--- a/test-app/mocks/mockClients/reports/mockVariants/filter-input-examples/establishmentsAutocomplete.js
+++ b/test-app/mocks/mockClients/reports/mockVariants/filter-input-examples/establishmentsAutocomplete.js
@@ -1,0 +1,38 @@
+const variant25 = {
+  id: 'establishmentAutocomplete',
+  name: 'Establishment autocomplete',
+  description: 'Establishment autocomplete example',
+  resourceName: 'reports/list',
+  classification: 'OFFICIAL',
+  printable: false,
+  specification: {
+    template: 'list',
+    fields: [
+      {
+        name: 'establishment',
+        display: 'Establishment',
+        sortable: false,
+        visible: true,
+        type: 'date',
+        mandatory: false,
+        filter: {
+          type: 'autocomplete',
+          dynamicOptions: {
+            minimumLength: 3,
+            returnAsStaticOptions: true,
+          },
+          staticOptions: [
+            { name: 'MDI', display: 'Moorland (HMP & YOI)' },
+            { name: 'KMI', display: 'KIRKHAM (HMP)' },
+            { name: 'LCI', display: 'LEICESTER' },
+            { name: 'MSI', display: 'MAIDSTONE (HMP)' },
+            { name: 'VMI', display: 'WYMOTT (HMP)' },
+          ],
+          mandatory: false,
+        },
+      },
+    ],
+  },
+}
+
+module.exports = variant25

--- a/test-app/mocks/mockClients/reports/mockVariants/filter-input-examples/index.js
+++ b/test-app/mocks/mockClients/reports/mockVariants/filter-input-examples/index.js
@@ -1,5 +1,6 @@
 const granularDateRange = require('./granularDateRange')
 const relativeDateRange = require('./relativeDateRange')
 const relativeDateRangeDefault = require('./relativeDateRangeWithDefaults')
+const establishmentsAutocomplete = require('./establishmentsAutocomplete')
 
-module.exports = [granularDateRange, relativeDateRange, relativeDateRangeDefault]
+module.exports = [granularDateRange, relativeDateRange, relativeDateRangeDefault, establishmentsAutocomplete]

--- a/test-app/utils/initMockClients.ts
+++ b/test-app/utils/initMockClients.ts
@@ -8,7 +8,6 @@ import ReportDataStore from '../../src/dpr/data/reportDataStore'
 import createDprServices from '../../src/dpr/utils/ReportStoreServiceUtils'
 import setUpDprResources from '../../src/dpr/middleware/setUpDprResources'
 import MissingReportClient from '../../src/dpr/services/missingReport/missingReportClient'
-import { Services } from '../../src/dpr/types/Services'
 
 export default function initMockClients(router: Router, featureConfig?: { bookmarking?: boolean; download?: boolean }) {
   // 1. Init Data clients
@@ -16,16 +15,16 @@ export default function initMockClients(router: Router, featureConfig?: { bookma
   const dashboardClient = new MockDashboardClient() as unknown as DashboardClient
   const reportDataStore = new MockUserStoreService() as unknown as ReportDataStore
   const missingReportClient = new MissingReportClient({
-      agent: {
-        timeout: 1000,
-      },
-      url: `http://localhost:9091`,
-    })
+    agent: {
+      timeout: 1000,
+    },
+    url: `http://localhost:9091`,
+  })
 
   // 2. Create services
   const services = {
     ...createDprServices({ reportingClient, dashboardClient, reportDataStore }, featureConfig),
-    missingReportClient
+    missingReportClient,
   }
 
   router.use(setUpDprResources(services))


### PR DESCRIPTION
### Establishment pre population name issue

- Setting the default value for the establishment autocomplete now correctly uses the display name for an establishment, whilst correctly setting the query param value as the establishment code

### dprContext setup

- Fix for reported request to add a dprContext to res.locals to avoid any clashes with how services populate their user