### PR TITLE
Fix sort

### DIFF
--- a/src/dpr/routes/journeys/view-report/async/report/utils.ts
+++ b/src/dpr/routes/journeys/view-report/async/report/utils.ts
@@ -81,8 +81,8 @@ const getReportData = async (args: {
   const { variant } = definition
   const { specification } = variant
   const queryParams = {
-    ...(requestData.query?.data?.sortColumn && { sortColumn: requestData.query?.data?.sortColumn }),
-    ...(requestData.query?.data?.sortedAsc && { sortedAsc: requestData.query?.data?.sortedAsc }),
+    ...(requestData.query?.data?.sortColumn && { sortColumn: requestData.query.data.sortColumn }),
+    ...(requestData.query?.data?.sortedAsc && { sortedAsc: requestData.query.data.sortedAsc }),
     ...req.query,
   }
 
@@ -92,8 +92,6 @@ const getReportData = async (args: {
     queryParams,
     definitionsPath,
   })
-
-  console.log(JSON.stringify({ reportQuery }, null, 2))
 
   const reportData = await services.reportingService.getAsyncReport(
     token,


### PR DESCRIPTION
The query params in the request to get the data was defaulting the sort params back to the default in the DPD. 

This pr fixes this by setting the sort params by the requested sort params 