### PR TITLE
Dpr2 2193 Download sort bug

### DIFF
--- a/src/dpr/components/_reports/report-actions/types.d.ts
+++ b/src/dpr/components/_reports/report-actions/types.d.ts
@@ -15,6 +15,8 @@ export interface DownloadActionParams {
   currentUrl: string
   currentQueryParams: string
   nestedBaseUrl: string
+  sortColumn: string
+  sortedAsc: string
 }
 
 export interface ShareActionParams {

--- a/src/dpr/components/_reports/report-actions/view.njk
+++ b/src/dpr/components/_reports/report-actions/view.njk
@@ -35,6 +35,8 @@
         <input type="hidden" name="loadType" value="{{ button.attributes.loadType }}">
         <input type="hidden" name="currentUrl" value="{{ button.attributes.currentUrl }}">
         <input type="hidden" name="currentQueryParams" value="{{ button.attributes.currentQueryParams }}">
+        <input type="hidden" name="sortedAsc" value="{{ button.attributes.sortedAsc }}">
+        <input type="hidden" name="sortColumn" value="{{ button.attributes.sortColumn }}">
       </form>
     {% endif %}
 

--- a/src/dpr/components/user-reports/utils.ts
+++ b/src/dpr/components/user-reports/utils.ts
@@ -1,6 +1,5 @@
 import { Response, Request } from 'express'
 import dayjs from 'dayjs'
-import customParse from 'dayjs/plugin/customParseFormat'
 import { RenderTableListResponse } from './types'
 import Dict = NodeJS.Dict
 import {

--- a/src/dpr/data/restClient.ts
+++ b/src/dpr/data/restClient.ts
@@ -48,7 +48,7 @@ export default class RestClient {
     token: string,
   ): Promise<Response> {
     logger.info(`${this.name} ${method.toUpperCase()}: ${path}`)
-    console.log(`info about request: ${method} | ${path} | ${JSON.stringify(data)} | ${query}`)
+    logger.info(`info about request: ${method} | ${path} | ${JSON.stringify(data)} | ${query}`)
     try {
       const result = await superagent[method](`${this.apiUrl()}${path}`)
         .query(query)

--- a/src/dpr/middleware/setUpDprResources.ts
+++ b/src/dpr/middleware/setUpDprResources.ts
@@ -5,7 +5,6 @@ import { Services } from '../types/Services'
 import { RequestedReport, StoredReportData } from '../types/UserReports'
 import DefinitionUtils from '../utils/definitionUtils'
 import { BookmarkStoreData } from '../types/Bookmark'
-import { getRoutePrefix } from '../utils/urlHelper'
 import { DprConfig } from '../types/DprConfig'
 import localsHelper from '../utils/localsHelper'
 

--- a/src/dpr/routes/journeys/request-missing-report/form/controller.ts
+++ b/src/dpr/routes/journeys/request-missing-report/form/controller.ts
@@ -1,5 +1,4 @@
 import { RequestHandler } from 'express'
-import { Response } from 'superagent'
 import LocalsHelper from '../../../../utils/localsHelper'
 import { components } from '../../../../types/api'
 import { Services } from '../../../../types/Services'

--- a/src/dpr/routes/journeys/view-report/async/report/utils.ts
+++ b/src/dpr/routes/journeys/view-report/async/report/utils.ts
@@ -82,7 +82,7 @@ const getReportData = async (args: {
   const { specification } = variant
   const queryParams = {
     ...(requestData.query?.data?.sortColumn && { sortColumn: requestData.query?.data?.sortColumn }),
-    ...(requestData.query?.data?.sortedAsc && { sortColumn: requestData.query?.data?.sortedAsc }),
+    ...(requestData.query?.data?.sortedAsc && { sortedAsc: requestData.query?.data?.sortedAsc }),
     ...req.query,
   }
 
@@ -92,6 +92,8 @@ const getReportData = async (args: {
     queryParams,
     definitionsPath,
   })
+
+  console.log(JSON.stringify({ reportQuery }, null, 2))
 
   const reportData = await services.reportingService.getAsyncReport(
     token,

--- a/src/dpr/routes/journeys/view-report/async/report/utils.ts
+++ b/src/dpr/routes/journeys/view-report/async/report/utils.ts
@@ -441,7 +441,7 @@ const setActions = (
   currentQueryParams: string,
   res: Response,
 ) => {
-  const { reportName, name, id, variantId, reportId, tableId, executionId, dataProductDefinitionsPath, url } =
+  const { reportName, name, id, variantId, reportId, tableId, executionId, dataProductDefinitionsPath, url, query } =
     requestData
   const { nestedBaseUrl } = LocalsHelper.getValues(res)
   const requestUrl = url.request.fullUrl
@@ -463,6 +463,8 @@ const setActions = (
     currentUrl,
     currentQueryParams,
     nestedBaseUrl,
+    sortColumn: query?.data?.sortColumn,
+    sortedAsc: query?.data?.sortedAsc,
   }
 
   const shareConfig = {

--- a/src/dpr/routes/journeys/view-report/async/report/utils.ts
+++ b/src/dpr/routes/journeys/view-report/async/report/utils.ts
@@ -43,8 +43,6 @@ export const getData = async ({
   // Get the request data
   const requestData: RequestedReport = await services.requestedReportService.getReportByTableId(tableId, userId)
 
-  console.log(JSON.stringify({ requestData }, null, 2))
-
   // Get the reportData
   const { reportData, reportQuery } = await getReportData({ definition, services, token, req, res, requestData })
 
@@ -82,10 +80,9 @@ const getReportData = async (args: {
   const reportVariantId = variantId || id
   const { variant } = definition
   const { specification } = variant
-  const { sortColumn, sortedAsc } = requestData.query.data
   const queryParams = {
-    ...(sortColumn && { sortColumn }),
-    ...(sortedAsc && { sortedAsc }),
+    ...(requestData.query?.data?.sortColumn && { sortColumn: requestData.query?.data?.sortColumn }),
+    ...(requestData.query?.data?.sortedAsc && { sortColumn: requestData.query?.data?.sortedAsc }),
     ...req.query,
   }
 

--- a/src/dpr/routes/journeys/view-report/async/report/utils.ts
+++ b/src/dpr/routes/journeys/view-report/async/report/utils.ts
@@ -81,8 +81,8 @@ const getReportData = async (args: {
   const { variant } = definition
   const { specification } = variant
   const queryParams = {
-    ...(requestData.query?.data?.sortColumn && { sortColumn: requestData.query?.data?.sortColumn }),
-    ...(requestData.query?.data?.sortedAsc && { sortedAsc: requestData.query?.data?.sortedAsc }),
+    ...(requestData.query?.data?.sortColumn && { sortColumn: requestData.query.data.sortColumn }),
+    ...(requestData.query?.data?.sortedAsc && { sortedAsc: requestData.query.data.sortedAsc }),
     ...req.query,
   }
 
@@ -92,8 +92,6 @@ const getReportData = async (args: {
     queryParams,
     definitionsPath,
   })
-
-  console.log(JSON.stringify({ reportQuery }, null, 2))
 
   const reportData = await services.reportingService.getAsyncReport(
     token,


### PR DESCRIPTION
### Download sorting bug fix
Download sorting was not applied correctly and was defaulting back to DPD default sort
- the get data endpoint requires the sort query params otherwise it resorts back to defaults

### Other fixes
Remove html tags for multiple fields instead of single field. 