### PR TITLE
Chunk tableIds and hit the batch expirey api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Below you can find the changes included in each release.
 
+## 6.1.0
+
+- Batching table IDs into size‑limited chunks to make paginated API calls to expire check endpoint and aggregating the results.
+
 ## 6.0.3
 
 - Bugfix: string.replace causing template error when name/variantName is undefined

--- a/src/dpr/data/restClient.ts
+++ b/src/dpr/data/restClient.ts
@@ -121,7 +121,7 @@ class RestClient {
     token: string,
   ): Promise<Response> {
     logger.info(`${this.name} ${method.toUpperCase()}: ${path}`)
-    logger.info(`info about request: ${method} | ${path} | ${JSON.stringify(data)} | ${query}`)
+    logger.info(`info about request: ${method} | ${path} | ${JSON.stringify(data)} | ${JSON.stringify(query)}`)
     try {
       const result = await superagent[method](`${this.apiUrl()}${path}`)
         .query(query)

--- a/src/dpr/utils/ReportStatus/getReportStatus.ts
+++ b/src/dpr/utils/ReportStatus/getReportStatus.ts
@@ -14,6 +14,7 @@ import { Services } from '../../types/Services'
 import { StoredReportData, ReportType, RequestedReport } from '../../types/UserReports'
 import { getValues } from '../localsHelper'
 import { getAllMyReports } from '../reportStoreHelper'
+import { components } from '../../types/api'
 
 /**
  * ------------------------------------------------------------
@@ -470,11 +471,15 @@ async function detectExpiredFinishedReports({
   const tableIds = [...new Set(finishedWithTables.map((r) => r.tableId!))]
 
   const batches = chunkArray(tableIds, 50)
-  const expiryStates = await batches.reduce<Promise<any[]>>(async (accPromise, batch) => {
-    const acc = await accPromise
-    const result = await services.reportingService.getTableExpiryState(token, batch)
-    return [...acc, ...result]
-  }, Promise.resolve([]))
+
+  const expiryStates = await batches.reduce<Promise<components['schemas']['ResultTableExpiryState'][]>>(
+    async (accPromise, batch) => {
+      const acc = await accPromise
+      const result = await services.reportingService.getTableExpiryState(token, batch)
+      return [...acc, ...result]
+    },
+    Promise.resolve([]),
+  )
 
   const expiredTableIds = new Set(expiryStates.filter((s) => s.expired).map((s) => s.tableId))
 

--- a/src/dpr/utils/ReportStatus/getReportStatus.ts
+++ b/src/dpr/utils/ReportStatus/getReportStatus.ts
@@ -469,12 +469,20 @@ async function detectExpiredFinishedReports({
   // de‑duplicate tableIds for batch lookup
   const tableIds = [...new Set(finishedWithTables.map((r) => r.tableId!))]
 
-  const expiryStates = await services.reportingService.getTableExpiryState(token, tableIds)
+  const batches = chunkArray(tableIds, 50)
+  const expiryStates = await batches.reduce<Promise<any[]>>(async (accPromise, batch) => {
+    const acc = await accPromise
+    const result = await services.reportingService.getTableExpiryState(token, batch)
+    return [...acc, ...result]
+  }, Promise.resolve([]))
 
   const expiredTableIds = new Set(expiryStates.filter((s) => s.expired).map((s) => s.tableId))
 
   return finishedWithTables.filter((r) => expiredTableIds.has(r.tableId!)).map((r) => ({ executionId: r.executionId! }))
 }
+
+const chunkArray = <T>(arr: T[], size: number): T[][] =>
+  Array.from({ length: Math.ceil(arr.length / size) }, (_, i) => arr.slice(i * size, i * size + size))
 
 /**
  * Checks the expired status of reports and updates the state

--- a/src/dpr/utils/ReportStatus/getReportStatus.ts
+++ b/src/dpr/utils/ReportStatus/getReportStatus.ts
@@ -15,6 +15,7 @@ import { StoredReportData, ReportType, RequestedReport } from '../../types/UserR
 import { getValues } from '../localsHelper'
 import { getAllMyReports } from '../reportStoreHelper'
 import { components } from '../../types/api'
+import logger from '../logger'
 
 /**
  * ------------------------------------------------------------
@@ -480,6 +481,7 @@ async function detectExpiredFinishedReports({
     },
     Promise.resolve([]),
   )
+  logger.info(`EXPIRED STATES: ${JSON.stringify(expiryStates)}`)
 
   const expiredTableIds = new Set(expiryStates.filter((s) => s.expired).map((s) => s.tableId))
 
@@ -529,6 +531,7 @@ export async function expireFinishedReports({
 
   // de-duplicate executionIds
   const uniqueExpired = [...new Map(expired.map((e) => [e.executionId, e])).values()]
+  logger.info(`EXPIRED STATES: ${JSON.stringify({ uniqueExpired })}`)
 
   // If any expired then update the state
   await uniqueExpired.reduce(async (prev, { executionId }) => {


### PR DESCRIPTION
Batch check expirey endpoint has a max data count of 50.

- Chunk ids into blocks of 50
- call API repeatedly until all ids are sent and aggregate the result
- Debugging logs to validate FE expiry process