### PR TITLE
Dpr2 2686 return normal casing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ Below you can find the changes included in each release.
 
 ## 6.4.0
 
+- Bugfix: Statics options should not be normalized before query
+
+## 6.4.0
+
 - `autocompletemulti` validates against `minSelected` and `maxSelected` filter definition fields
 
 ## 6.3.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 Below you can find the changes included in each release.
 
-## 6.4.0
+## 6.4.1
 
 - Bugfix: Statics options should not be normalized before query
 

--- a/src/dpr/types/ReportQuery.ts
+++ b/src/dpr/types/ReportQuery.ts
@@ -166,9 +166,10 @@ class ReportQuery implements FilteredListRequest {
   ): string | undefined {
     if (!staticOptions || !rawValue) return undefined
 
-    const validValues = staticOptions.map((o) => o.name.toLowerCase())
+    // Map lowercase -> original casing
+    const valueMap = new Map(staticOptions.map((o) => [o.name.toLowerCase(), o.name]))
 
-    // Normalize input - array of strings
+    // Normalize input to lowercase strings
     const values = Array.isArray(rawValue)
       ? rawValue.map((v) => v.toString().toLowerCase())
       : rawValue
@@ -177,8 +178,9 @@ class ReportQuery implements FilteredListRequest {
           .map((v) => v.trim().toLowerCase())
 
     if (type === 'multiselect') {
-      const invalidValues = values.filter((v) => !validValues.includes(v))
-      const filtered = [...new Set(values.filter((v) => validValues.includes(v)))]
+      const invalidValues = values.filter((v) => !valueMap.has(v))
+
+      const filtered = [...new Set(values.map((v) => valueMap.get(v)).filter((v): v is string => v !== undefined))]
 
       if (invalidValues.length > 0) {
         logger.warn(`Invalid filter values removed for multiselect: ${fieldName}: [${invalidValues.join(', ')}]`)
@@ -189,15 +191,16 @@ class ReportQuery implements FilteredListRequest {
       return filtered.join(',')
     }
 
-    // radio / select (single value)
+    // Single value (radio/select)
     const value = values[0]
+    const mappedValue = valueMap.get(value)
 
-    if (!validValues.includes(value)) {
+    if (!mappedValue) {
       logger.warn(`Invalid filter value: ${fieldName}: ${value}`)
       return undefined
     }
 
-    return value
+    return mappedValue
   }
 
   /**


### PR DESCRIPTION
The function that validates the static options introduced a bug that normalized the output to lowercase meaning query params are sent to the BE in lowercase, and not the correct casing of the static options. This PR fixes that
