### PR TITLE
DPR2-2799 increase expiry check batch to 200

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Below you can find the changes included in each release.
 
+## 6.6.3
+- Updated batch of table IDs to check for expiry state to 200 from 50.
+
 ## 6.6.2
 
 - Update some dependencies to fix vulnerabilities

--- a/src/dpr/utils/ReportStatus/getReportStatus.ts
+++ b/src/dpr/utils/ReportStatus/getReportStatus.ts
@@ -471,7 +471,7 @@ async function detectExpiredFinishedReports({
   // de‑duplicate tableIds for batch lookup
   const tableIds = [...new Set(finishedWithTables.map((r) => r.tableId!))]
 
-  const batches = chunkArray(tableIds, 50)
+  const batches = chunkArray(tableIds, 200)
 
   const expiryStates = await batches.reduce<Promise<components['schemas']['ResultTableExpiryState'][]>>(
     async (accPromise, batch) => {


### PR DESCRIPTION
Increase batch of tables to send in the expiry check request to 200 from 50 as the BE can handle up to 200 tableIds without issues.
This is in order to reduce the number of requests made.